### PR TITLE
feat: add ride vehicle selection

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -245,6 +245,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private View mRoutingSummaryPanel;
   private TextView mCarPrice;
   private TextView mMotorcyclePrice;
+  private com.google.android.material.button.MaterialButton mSelectCarButton;
+  private com.google.android.material.button.MaterialButton mSelectMotorcycleButton;
 
   private enum CalculationState
   {
@@ -597,6 +599,23 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mRoutingSummaryPanel = findViewById(R.id.routing_summary_panel);
     mCarPrice = mRoutingSummaryPanel.findViewById(R.id.tv_car_price);
     mMotorcyclePrice = mRoutingSummaryPanel.findViewById(R.id.tv_motorcycle_price);
+    mSelectCarButton = mRoutingSummaryPanel.findViewById(R.id.btn_select_car);
+    mSelectMotorcycleButton = mRoutingSummaryPanel.findViewById(R.id.btn_select_motorcycle);
+
+    mSelectCarButton.setOnClickListener(v -> {
+      RoutingController controller = RoutingController.get();
+      controller.setRouterType(Router.Vehicle);
+      onRoutingStart();
+      exitRideHailingMode();
+    });
+
+    mSelectMotorcycleButton.setOnClickListener(v -> {
+      RoutingController controller = RoutingController.get();
+      controller.setRouterType(Router.Bicycle);
+      if (mMotorcycleRouteDistance != 0)
+        onRoutingStart();
+      exitRideHailingMode();
+    });
 
     updateViewsInsets();
 
@@ -1653,6 +1672,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onNavigationCancelled()
   {
+    exitRideHailingMode();
     closeFloatingToolbarsAndPanels(true);
     ThemeSwitcher.INSTANCE.restart(isMapRendererActive());
     if (mRoutingPlanInplaceController == null)

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -128,6 +128,22 @@
           tools:text="Rp 24.000" />
     </LinearLayout>
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_select_car"
+        style="@style/MwmWidget.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Pilih Mobil" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_select_motorcycle"
+        style="@style/MwmWidget.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Pilih Motor" />
+
   </LinearLayout>
   <com.google.android.material.button.MaterialButton
       android:id="@+id/confirm_pickup_button"


### PR DESCRIPTION
## Summary
- add car and motorcycle selection buttons to routing summary panel
- handle car and motorcycle selection in `MwmActivity`
- hide summary panel when navigation is cancelled

## Testing
- `./gradlew test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688b6dc5361083299ac6c3e830d310cf