### PR TITLE
Preload map using dummy surface

### DIFF
--- a/app/src/main/java/app/organicmaps/MapFragment.java
+++ b/app/src/main/java/app/organicmaps/MapFragment.java
@@ -16,7 +16,6 @@ import androidx.core.content.res.ConfigurationHelper;
 import app.organicmaps.base.BaseMwmFragment;
 import app.organicmaps.sdk.Map;
 import app.organicmaps.sdk.MapRenderingListener;
-import app.organicmaps.sdk.display.DisplayType;
 import app.organicmaps.sdk.util.log.Logger;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -57,6 +56,7 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   public void surfaceCreated(@NonNull SurfaceHolder surfaceHolder)
   {
     Logger.d(TAG);
+    MwmApplication.from(requireContext()).detachDummySurface();
     int densityDpi;
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
@@ -87,7 +87,8 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   {
     Logger.d(TAG);
     super.onAttach(context);
-    mMap = new Map(DisplayType.Device, MwmApplication.from(requireContext()).getLocationHelper());
+    MwmApplication app = MwmApplication.from(requireContext());
+    mMap = app.getMap();
     mMap.setMapRenderingListener((MapRenderingListener) context);
     mMap.setCallbackUnsupported(this::reportUnsupported);
   }

--- a/app/src/main/java/app/organicmaps/MwmApplication.java
+++ b/app/src/main/java/app/organicmaps/MwmApplication.java
@@ -7,6 +7,9 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.graphics.Rect;
+import android.graphics.SurfaceTexture;
+import android.view.Surface;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
@@ -21,6 +24,7 @@ import app.organicmaps.routing.NavigationService;
 import app.organicmaps.sdk.Map;
 import app.organicmaps.sdk.OrganicMaps;
 import app.organicmaps.sdk.display.DisplayManager;
+import app.organicmaps.sdk.display.DisplayType;
 import app.organicmaps.sdk.location.LocationHelper;
 import app.organicmaps.sdk.location.LocationState;
 import app.organicmaps.sdk.location.SensorHelper;
@@ -51,6 +55,13 @@ public class MwmApplication extends Application implements Application.ActivityL
 
   @Nullable
   private WeakReference<Activity> mTopActivity;
+
+  @Nullable
+  private Map mPreloadedMap;
+  @Nullable
+  private SurfaceTexture mDummyTexture;
+  @Nullable
+  private Surface mDummySurface;
 
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
@@ -139,6 +150,45 @@ public class MwmApplication extends Application implements Application.ActivityL
       ProcessLifecycleOwner.get().getLifecycle().addObserver(mProcessLifecycleObserver);
       onComplete.run();
     });
+  }
+
+  public void prepareDummyMap()
+  {
+    if (mPreloadedMap != null)
+      return;
+    mPreloadedMap = new Map(DisplayType.Device, getLocationHelper());
+    mDummyTexture = new SurfaceTexture(0);
+    mDummyTexture.setDefaultBufferSize(1, 1);
+    mDummySurface = new Surface(mDummyTexture);
+    Rect frame = new Rect(0, 0, 1, 1);
+    int dpi = getResources().getDisplayMetrics().densityDpi;
+    mPreloadedMap.onSurfaceCreated(this, mDummySurface, frame, dpi);
+    mPreloadedMap.onSurfaceChanged(this, mDummySurface, frame, true);
+    mPreloadedMap.onStart();
+    mPreloadedMap.onResume();
+  }
+
+  @NonNull
+  public Map getMap()
+  {
+    if (mPreloadedMap == null)
+      mPreloadedMap = new Map(DisplayType.Device, getLocationHelper());
+    return mPreloadedMap;
+  }
+
+  public void detachDummySurface()
+  {
+    if (mPreloadedMap != null && mDummySurface != null)
+    {
+      mPreloadedMap.onSurfaceDestroyed(false, true);
+      mDummySurface.release();
+      mDummySurface = null;
+    }
+    if (mDummyTexture != null)
+    {
+      mDummyTexture.release();
+      mDummyTexture = null;
+    }
   }
 
   private final LifecycleObserver mProcessLifecycleObserver = new DefaultLifecycleObserver() {

--- a/app/src/main/java/app/organicmaps/search/SearchActivity.java
+++ b/app/src/main/java/app/organicmaps/search/SearchActivity.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.fragment.app.Fragment;
+import app.organicmaps.MwmApplication;
 import app.organicmaps.base.BaseMwmFragmentActivity;
 import app.organicmaps.util.ThemeUtils;
 
@@ -46,5 +47,12 @@ public class SearchActivity extends BaseMwmFragmentActivity
   protected Class<? extends Fragment> getFragmentClass()
   {
     return SearchFragment.class;
+  }
+
+  @Override
+  protected void onSafeCreate(@Nullable Bundle savedInstanceState)
+  {
+    super.onSafeCreate(savedInstanceState);
+    MwmApplication.from(this).prepareDummyMap();
   }
 }


### PR DESCRIPTION
## Summary
- preload Map instance with 1x1 dummy surface to warm up engine before opening map
- prepare dummy map in SearchActivity to avoid visible glitches
- reuse preloaded Map in MapFragment and detach dummy surface once real surface is ready

## Testing
- `./gradlew assembleDebug` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688c220ac2708329a774efbaaaa8d46f