### PR TITLE
Tampilkan hasil pencarian dari SearchActivity

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -323,6 +323,13 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     intent.putExtra(EXTRA_CONSUMED, true);
 
+    final int resultIndex = intent.getIntExtra(SearchActivity.EXTRA_RESULT_INDEX, -1);
+    if (resultIndex != -1)
+    {
+      SearchEngine.INSTANCE.showResult(resultIndex);
+      return;
+    }
+
     final long categoryId = intent.getLongExtra(EXTRA_CATEGORY_ID, -1);
     final long bookmarkId = intent.getLongExtra(EXTRA_BOOKMARK_ID, -1);
     final long trackId = intent.getLongExtra(EXTRA_TRACK_ID, -1);

--- a/app/src/main/java/app/organicmaps/search/SearchActivity.java
+++ b/app/src/main/java/app/organicmaps/search/SearchActivity.java
@@ -19,6 +19,7 @@ public class SearchActivity extends BaseMwmFragmentActivity
   public static final String EXTRA_RESULT_NAME = "search_result_name";
   public static final String EXTRA_RESULT_LAT = "search_result_lat";
   public static final String EXTRA_RESULT_LON = "search_result_lon";
+  public static final String EXTRA_RESULT_INDEX = "search_result_index";
   public static void start(@NonNull Activity activity, @Nullable String query)
   {
     start(activity, query, null /* locale */, false /* isSearchOnMap */);

--- a/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -414,6 +414,8 @@ public class SearchFragment extends BaseMwmFragment implements SearchListener, C
     SearchEngine.INSTANCE.cancel();
     SearchEngine.INSTANCE.setQuery(query);
 
+    final Activity host = requireActivity();
+
     if (RoutingController.get().isWaitingPoiPick())
     {
       final String subtitle = (result.description != null) ? result.description.localizedFeatureType : "";
@@ -422,6 +424,18 @@ public class SearchFragment extends BaseMwmFragment implements SearchListener, C
       final MapObject point =
           MapObject.createMapObject(FeatureId.EMPTY, MapObject.SEARCH, title, subtitle, result.lat, result.lon);
       RoutingController.get().onPoiSelected(point);
+      mToolbarController.deactivate();
+      if (host instanceof SearchActivity)
+        Utils.navigateToParent(host);
+      return;
+    }
+
+    if (host instanceof SearchActivity)
+    {
+      final Intent intent = new Intent(host, MwmActivity.class);
+      intent.putExtra(SearchActivity.EXTRA_RESULT_INDEX, resultIndex);
+      host.startActivity(intent);
+      host.finish();
     }
     else
     {
@@ -429,9 +443,6 @@ public class SearchFragment extends BaseMwmFragment implements SearchListener, C
     }
 
     mToolbarController.deactivate();
-
-    if (requireActivity() instanceof SearchActivity)
-      Utils.navigateToParent(requireActivity());
   }
 
   void showAllResultsOnMap()


### PR DESCRIPTION
## Ringkasan
- Tambah konstanta `EXTRA_RESULT_INDEX` untuk meneruskan indeks hasil pencarian dari SearchActivity.
- Ubah `showSingleResultOnMap()` agar SearchActivity membuka MwmActivity dengan indeks hasil tanpa memanggil `SearchEngine.showResult()`.
- Perluas `MwmActivity.processIntent()` untuk membaca `EXTRA_RESULT_INDEX` dan menampilkan hasil setelah mesin siap.

## Pengujian
- `bash gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_688c278898ec8329b9ada5e6698e6dd0