### PR TITLE
Skip search on first launch when returning from SearchActivity

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -554,6 +554,14 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   protected void onSafeCreate(@Nullable Bundle savedInstanceState)
   {
+    final Intent startIntent = getIntent();
+    if (startIntent != null &&
+        (startIntent.hasExtra(SearchActivity.EXTRA_RESULT_INDEX) ||
+         startIntent.getBooleanExtra(SearchActivity.EXTRA_FROM_SEARCH, false)))
+    {
+      sIsFirstLaunch = false;
+    }
+
     super.onSafeCreate(savedInstanceState);
 
     mIsTabletLayout = getResources().getBoolean(R.bool.tabletLayout);

--- a/app/src/main/java/app/organicmaps/search/SearchActivity.java
+++ b/app/src/main/java/app/organicmaps/search/SearchActivity.java
@@ -20,6 +20,7 @@ public class SearchActivity extends BaseMwmFragmentActivity
   public static final String EXTRA_RESULT_LAT = "search_result_lat";
   public static final String EXTRA_RESULT_LON = "search_result_lon";
   public static final String EXTRA_RESULT_INDEX = "search_result_index";
+  public static final String EXTRA_FROM_SEARCH = "search_from_search_activity";
   public static void start(@NonNull Activity activity, @Nullable String query)
   {
     start(activity, query, null /* locale */, false /* isSearchOnMap */);

--- a/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -434,6 +434,7 @@ public class SearchFragment extends BaseMwmFragment implements SearchListener, C
     {
       final Intent intent = new Intent(host, MwmActivity.class);
       intent.putExtra(SearchActivity.EXTRA_RESULT_INDEX, resultIndex);
+      intent.putExtra(SearchActivity.EXTRA_FROM_SEARCH, true);
       host.startActivity(intent);
       host.finish();
     }


### PR DESCRIPTION
## Summary
- Hindari membuka SearchActivity pada peluncuran pertama jika intent dari SearchActivity membawa hasil atau penanda khusus.
- Tambahkan flag `EXTRA_FROM_SEARCH` untuk menandai intent yang berasal dari SearchActivity.

## Testing
- `./gradlew test` *(gagal: A problem occurred evaluating root project 'Organic Maps'. Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688c2c09436c8329aec6b7f920781f02