### PR TITLE
Siapkan dummy map di SplashActivity sebelum SearchActivity

### DIFF
--- a/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -186,6 +186,7 @@ public class SplashActivity extends AppCompatActivity
     // https://github.com/organicmaps/organicmaps/issues/6944
     final Intent intent = Objects.requireNonNull(getIntent());
     final int bytesToDownload = DownloadResourcesLegacyActivity.nativeGetBytesToDownload();
+    boolean openSearch = false;
 
     if (isManageSpaceActivity(intent))
     {
@@ -194,6 +195,7 @@ public class SplashActivity extends AppCompatActivity
     else if (bytesToDownload == 0)
     {
       intent.setComponent(new ComponentName(this, SearchActivity.class));
+      openSearch = true;
     }
     else
     {
@@ -214,6 +216,8 @@ public class SplashActivity extends AppCompatActivity
     }
 
     Config.setFirstStartDialogSeen(this);
+    if (openSearch)
+      MwmApplication.from(this).prepareDummyMap();
     startActivity(intent);
     finish();
   }

--- a/app/src/main/java/app/organicmaps/search/SearchActivity.java
+++ b/app/src/main/java/app/organicmaps/search/SearchActivity.java
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.fragment.app.Fragment;
-import app.organicmaps.MwmApplication;
 import app.organicmaps.base.BaseMwmFragmentActivity;
 import app.organicmaps.util.ThemeUtils;
 
@@ -55,6 +54,5 @@ public class SearchActivity extends BaseMwmFragmentActivity
   protected void onSafeCreate(@Nullable Bundle savedInstanceState)
   {
     super.onSafeCreate(savedInstanceState);
-    MwmApplication.from(this).prepareDummyMap();
   }
 }


### PR DESCRIPTION
## Ringkasan
- Siapkan dummy map di `SplashActivity` saat membuka `SearchActivity`.
- Hapus pemanggilan `prepareDummyMap()` dari `SearchActivity` agar tidak dipanggil ganda.

## Pengujian
- `./gradlew test` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688c3730ca988329a96f6dbd55ac12bc