### PR TITLE
Reset state after routing build errors

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -128,6 +128,7 @@ import app.organicmaps.widget.placepage.PlacePageController;
 import app.organicmaps.widget.placepage.PlacePageViewModel;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Objects;
 import app.organicmaps.sdk.routing.RoutingInfo;
 
@@ -1919,9 +1920,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onCommonBuildError(int lastResultCode, @NonNull String[] lastMissingMaps)
   {
+    Logger.e(TAG, "Routing build error: code=" + lastResultCode + ", missingMaps=" + Arrays.toString(lastMissingMaps));
     RoutingErrorDialogFragment fragment = RoutingErrorDialogFragment.create(
         getSupportFragmentManager().getFragmentFactory(), getApplicationContext(), lastResultCode, lastMissingMaps);
     fragment.show(getSupportFragmentManager(), RoutingErrorDialogFragment.class.getSimpleName());
+    mCalculationState = CalculationState.NONE;
+    UiUtils.hide(mRoutingProgressOverlay);
   }
 
   @Override


### PR DESCRIPTION
## Summary
- Log detail of routing build errors and missing maps
- Reset calculation state to NONE and hide progress overlay after showing routing error dialog

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688c9b8938308329b94e11ff9e83ec42