### PR TITLE
Tunda penghapusan rute sampai core siap

### DIFF
--- a/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -22,6 +22,7 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import app.organicmaps.downloader.DownloaderActivity;
 import app.organicmaps.intent.Factory;
+import app.organicmaps.sdk.Map;
 import app.organicmaps.sdk.display.DisplayManager;
 import app.organicmaps.sdk.location.LocationHelper;
 import app.organicmaps.sdk.routing.RoutingController;
@@ -75,9 +76,6 @@ public class SplashActivity extends AppCompatActivity
 
     RoutingController controller = RoutingController.get();
     controller.cancel();
-    controller.deleteSavedRoute();
-    if (controller.hasSavedRoute())
-      Logger.w(TAG, "Saved route not cleared");
 
     ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.root_view), new OnApplyWindowInsetsListener() {
       @NonNull
@@ -185,6 +183,18 @@ public class SplashActivity extends AppCompatActivity
     {
       Logger.w(TAG, "Ignore late callback from core because activity is already destroyed");
       return;
+    }
+
+    if (Map.isEngineCreated())
+    {
+      RoutingController controller = RoutingController.get();
+      controller.deleteSavedRoute();
+      if (controller.hasSavedRoute())
+        Logger.w(TAG, "Saved route not cleared");
+    }
+    else
+    {
+      Logger.w(TAG, "Engine not created, skip deleting saved route");
     }
 
     // Re-use original intent with the known safe subset of flags to retain security permissions.

--- a/app/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
+++ b/app/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
 import app.organicmaps.sdk.Framework;
+import app.organicmaps.sdk.Map;
 import app.organicmaps.sdk.Router;
 import app.organicmaps.sdk.bookmarks.data.FeatureId;
 import app.organicmaps.sdk.bookmarks.data.MapObject;
@@ -304,6 +305,11 @@ public class RoutingController
 
   public void deleteSavedRoute()
   {
+    if (!Map.isEngineCreated())
+    {
+      Logger.w(TAG, "Engine not created, skip deleting saved route");
+      return;
+    }
     Framework.nativeDeleteSavedRoutePoints();
   }
 


### PR DESCRIPTION
## Ringkasan
- Hapus pemanggilan `deleteSavedRoute()` dari `SplashActivity.onCreate` dan jalankan di `processNavigation()` setelah engine siap.
- Tambahkan pemeriksaan `Map.isEngineCreated()` sebelum menghapus rute tersimpan.
- Jaga `RoutingController.deleteSavedRoute()` agar aman dipanggil sebelum engine dibuat.

## Pengujian
- `./gradlew test` (gagal karena skrip `../tools/unix/version.sh` tidak ditemukan)


------
https://chatgpt.com/codex/tasks/task_e_688cb12f93648329906d23b4df6c7fa0