### PR TITLE
Require destination confirmation

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -307,7 +307,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     else if (RoutingController.get().isNavigating())
       onNavigationStarted();
     else if (RoutingController.get().hasSavedRoute())
-      RoutingController.get().restoreRoute();
+      RoutingController.get().deleteSavedRoute();
 
     if (TrackRecorder.nativeIsTrackRecordingEnabled() && !startTrackRecording())
     {
@@ -2503,7 +2503,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     if (!mIsSelectingPickup)
     {
-      UiUtils.hide(mConfirmPickupButton);
       closePlacePage();
 
       if (mCurrentPlacePageObject == null)
@@ -2516,6 +2515,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       if (myPosition != null)
       {
         Framework.nativeSetViewportCenter(myPosition.getLat(), myPosition.getLon(), Framework.nativeGetDrawScale());
+        mPickupPoint = myPosition;
       }
       else
       {
@@ -2524,6 +2524,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
       mIsSelectingPickup = true;
       mConfirmPickupButton.setText(R.string.choose_this_pickup);
+      UiUtils.show(mConfirmPickupButton);
       Toast.makeText(this, R.string.tap_to_choose_pickup, Toast.LENGTH_SHORT).show();
     }
     else

--- a/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -28,8 +28,6 @@ import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmFragment;
 import app.organicmaps.downloader.CountrySuggestFragment;
 import app.organicmaps.sdk.Framework;
-import app.organicmaps.sdk.bookmarks.data.FeatureId;
-import app.organicmaps.sdk.bookmarks.data.MapObject;
 import app.organicmaps.sdk.downloader.MapManager;
 import app.organicmaps.sdk.location.LocationListener;
 import app.organicmaps.sdk.routing.RoutingController;
@@ -414,19 +412,7 @@ public class SearchFragment extends BaseMwmFragment implements SearchListener, C
     SearchEngine.INSTANCE.cancel();
     SearchEngine.INSTANCE.setQuery(query);
 
-    if (RoutingController.get().isWaitingPoiPick())
-    {
-      final String subtitle = (result.description != null) ? result.description.localizedFeatureType : "";
-      final String title = TextUtils.isEmpty(result.name) ? subtitle : result.name;
-
-      final MapObject point =
-          MapObject.createMapObject(FeatureId.EMPTY, MapObject.SEARCH, title, subtitle, result.lat, result.lon);
-      RoutingController.get().onPoiSelected(point);
-    }
-    else
-    {
-      SearchEngine.INSTANCE.showResult(resultIndex);
-    }
+    SearchEngine.INSTANCE.showResult(resultIndex);
 
     mToolbarController.deactivate();
 


### PR DESCRIPTION
## Summary
- jangan langsung konfirmasi destinasi ketika memilih hasil pencarian
- selalu tampilkan tombol konfirmasi penjemputan dan set posisi awal ke lokasi GPS
- hapus pemulihan rute tersimpan saat startup agar destinasi lama tidak muncul lagi

## Testing
- `./gradlew test` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688c0dc113288329acb20acd26527944