### PR TITLE
Cegah panel rute muncul di mode ride hailing

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1670,9 +1670,17 @@ public class MwmActivity extends BaseMwmFragmentActivity
       }
       else
       {
-        mRoutingPlanInplaceController.show(true);
-        if (completionListener != null)
-          completionListener.run();
+        if (mIsInRideHailingMode)
+        {
+          if (completionListener != null)
+            completionListener.run();
+        }
+        else
+        {
+          mRoutingPlanInplaceController.show(true);
+          if (completionListener != null)
+            completionListener.run();
+        }
       }
     }
     else
@@ -1721,6 +1729,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
 
     mRoutingPlanInplaceController.hideDrivingOptionsView();
+    mRoutingPlanInplaceController.show(false);
   }
 
   @Override
@@ -2580,6 +2589,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
       }
 
       UiUtils.hide(mConfirmPickupButton);
+      if (mRoutingPlanInplaceController != null)
+        mRoutingPlanInplaceController.show(false);
       RoutingController controller = RoutingController.get();
 
       mCarTollInfo = mCarNoTollInfo = mMotorcycleInfo = null;


### PR DESCRIPTION
## Ringkasan
- Lewati pemanggilan `mRoutingPlanInplaceController.show(true)` saat mode ride hailing sehingga panel rute tidak muncul.
- Sembunyikan panel rute lebih awal ketika konfirmasi pickup atau saat mulai menghitung rute.

## Pengujian
- `./gradlew test` (gagal: resource xml/network_security_config tidak ditemukan)


------
https://chatgpt.com/codex/tasks/task_e_688cca13cd848329a83fc4f87f484bdd