### PR TITLE
Skip manage route bottom sheet in ride‑hailing mode

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1549,6 +1549,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private boolean showAddStartOrFinishFrame(@NonNull RoutingController controller, boolean showFrame)
   {
+    if (mIsInRideHailingMode)
+      return false;
+
     // S - start, F - finish, L - my position
     // -S-F-L -> Start
     // -S-F+L -> Finish
@@ -2412,6 +2415,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onManageRouteOpen()
   {
+    if (mIsInRideHailingMode)
+    {
+      closeFloatingPanels();
+      return;
+    }
+
     // Create and show 'Manage Route' Bottom Sheet panel.
     mManageRouteBottomSheet = new ManageRouteBottomSheet();
     mManageRouteBottomSheet.setCancelable(false);


### PR DESCRIPTION
## Summary
- prevent Manage Route panel from opening when ride-hailing mode is active
- avoid routing bottom menu interactions in ride-hailing mode

## Testing
- `./gradlew test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688cd5c9d5d083299ba6d7335d9c2aee