### PR TITLE
Avoid opening manage route in ride-hailing

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1964,6 +1964,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mIsInRideHailingMode = false;
     setCalculationState(CalculationState.NONE);
     UiUtils.hide(mRoutingSummaryPanel);
+    UiUtils.hide(mRoutingProgressOverlay);
     mMapButtonsViewModel.setButtonsHidden(false);
   }
 
@@ -2424,10 +2425,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onManageRouteOpen()
   {
     if (mIsInRideHailingMode)
-    {
-      closeFloatingPanels();
       return;
-    }
 
     // Create and show 'Manage Route' Bottom Sheet panel.
     mManageRouteBottomSheet = new ManageRouteBottomSheet();


### PR DESCRIPTION
## Summary
- Skip Manage Route panel when ride-hailing mode is active
- Hide routing progress overlay on ride-hailing exit

## Testing
- `./gradlew test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688ce5f27c6483299420156319256059