### PR TITLE
Reset state dan sembunyikan overlay saat keluar dari mode ride-hailing

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -2425,7 +2425,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onManageRouteOpen()
   {
     if (mIsInRideHailingMode)
+    {
+      setCalculationState(CalculationState.NONE);
+      UiUtils.hide(mRoutingProgressOverlay);
       return;
+    }
 
     // Create and show 'Manage Route' Bottom Sheet panel.
     mManageRouteBottomSheet = new ManageRouteBottomSheet();


### PR DESCRIPTION
## Ringkasan
- Reset `mCalculationState` ke `NONE` dan sembunyikan `mRoutingProgressOverlay` ketika `onManageRouteOpen()` dipanggil saat mode ride-hailing aktif.

## Pengujian
- `./gradlew test` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688ce74b92388329a9a490c2914fa333