### PR TITLE
Hindari manage route saat ride hailing

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1875,9 +1875,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
         mMotorcycleInfo = info;
         mMotorcycleRouteDistance = info.distToTarget.mDistance;
         setCalculationState(CalculationState.NONE);
-        UiUtils.hide(mRoutingProgressOverlay);
         Logger.d(TAG, "onBuiltRoute: entering showRoutingSummary()");
         showRoutingSummary();
+        UiUtils.hide(mRoutingProgressOverlay);
         Logger.d(TAG, "onBuiltRoute: prices after showRoutingSummary: car (toll)=" + mCarTollPriceValue +
                      ", car (no toll)=" + mCarNoTollPriceValue +
                      ", motorcycle=" + mMotorcyclePriceValue);
@@ -2415,11 +2415,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onManageRouteOpen()
   {
     if (mIsInRideHailingMode)
-    {
-      setCalculationState(CalculationState.NONE);
-      UiUtils.hide(mRoutingProgressOverlay);
       return;
-    }
 
     // Create and show 'Manage Route' Bottom Sheet panel.
     mManageRouteBottomSheet = new ManageRouteBottomSheet();


### PR DESCRIPTION
## Ringkasan
- Abaikan pemanggilan Manage Route saat mode ride-hailing aktif.
- Sembunyikan routing progress overlay setelah ringkasan tarif ditampilkan.

## Pengujian
- `./gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)

------
https://chatgpt.com/codex/tasks/task_e_688cf1c21a7c8329a51a35c62a449f5a