### PR TITLE
Hindari panel Manage Route saat mode ride-hailing dan kembalikan layar pencarian awal

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -142,6 +142,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
 {
   private static final String TAG = MwmActivity.class.getSimpleName();
 
+  private static boolean sIsFirstLaunch = true;
+
   public static final String EXTRA_COUNTRY_ID = "country_id";
   public static final String EXTRA_CATEGORY_ID = "category_id";
   public static final String EXTRA_BOOKMARK_ID = "bookmark_id";
@@ -323,6 +325,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     processIntent();
     migrateOAuthCredentials();
+
+    if (sIsFirstLaunch)
+    {
+      sIsFirstLaunch = false;
+      showSearch("");
+    }
 
   }
 
@@ -2415,7 +2423,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onManageRouteOpen()
   {
     if (mIsInRideHailingMode)
+    {
+      if (mRoutingPlanInplaceController != null)
+        mRoutingPlanInplaceController.show(false);
       return;
+    }
 
     // Create and show 'Manage Route' Bottom Sheet panel.
     mManageRouteBottomSheet = new ManageRouteBottomSheet();


### PR DESCRIPTION
## Ringkasan
- Abaikan event Manage Route saat mode ride-hailing sehingga panel tidak pernah muncul dan perhitungan rute tidak terganggu.
- Pulihkan alur awal aplikasi dengan membuka layar pencarian setelah rendering pertama selesai.

## Pengujian
- `./gradlew test` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688cef597c0c832988895dc66b2c4668