### PR TITLE
Avoid routing panel in ride-hailing mode

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1627,6 +1627,13 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onRoutingPlanStartAnimate(boolean show)
   {
+    if (mIsInRideHailingMode)
+    {
+      if (mRoutingPlanInplaceController != null &&
+          UiUtils.isVisible(findViewById(R.id.routing_plan_frame)))
+        mRoutingPlanInplaceController.show(false);
+      return;
+    }
     // TODO This code section may be called when insets are not yet initialized
     // This is only a workaround to prevent crashes but a proper fix should be implemented
     if (mCurrentWindowInsets == null)


### PR DESCRIPTION
## Summary
- close routing plan panel when ride-hailing mode is active

## Testing
- `./gradlew test` *(fails: LicenceNotAcceptedException: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_688d0a2ae2bc832993dcbdf91103bc98