### PR TITLE
Clear manage route sheet after pickup confirmation

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -2620,6 +2620,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
       }
 
       UiUtils.hide(mConfirmPickupButton);
+      if (mManageRouteBottomSheet != null)
+        mManageRouteBottomSheet.dismiss();
+      mManageRouteBottomSheet = null;
       if (mRoutingPlanInplaceController != null)
         mRoutingPlanInplaceController.show(false);
       RoutingController controller = RoutingController.get();


### PR DESCRIPTION
## Summary
- dismiss ManageRouteBottomSheet when confirming pickup
- reset ManageRouteBottomSheet reference before showing routing plan

## Testing
- `./gradlew test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688d0c627e888329a3c113fd5ff564df