### PR TITLE
Handle manage route in ride hailing

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -2431,6 +2431,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     if (mIsInRideHailingMode)
     {
+      UiUtils.hide(mRoutingProgressOverlay);
+      setCalculationState(CalculationState.NONE);
       if (mRoutingPlanInplaceController != null)
         mRoutingPlanInplaceController.show(false);
       return;


### PR DESCRIPTION
## Summary
- stop showing routing progress when opening Manage Route in ride hailing mode
- reset calculation state when Manage Route is opened during ride hailing

## Testing
- `./gradlew testDebugUnitTest` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688d0de5170c8329b69ef1236946e1b9