### PR TITLE
Add cached route display for instant switching

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1967,44 +1967,34 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     if (mSelectedRouter == Router.Vehicle)
     {
-      // Cek apakah tipe router saat ini BUKAN Vehicle. Jika bukan, ganti.
-      // Ini untuk menghindari pemicu build yang tidak perlu jika pengguna hanya menekan tombol mobil berulang kali.
-      if (controller.getLastRouterType() != Router.Vehicle)
-      {
-        controller.setRouterType(Router.Vehicle);
-        // setRouterType sudah otomatis memicu build, jadi kita bisa langsung keluar.
-        // Namun, harga di UI belum ter-update, jadi kita biarkan kode di bawah tetap berjalan.
-      }
-
       long price;
+      RoutingInfo routeToDisplay;
+
       if (mTollSwitch.isChecked())
       {
         price = mCarTollPriceValue;
-        // Perintahkan untuk menghitung ulang dengan opsi TOL DIAKTIFKAN
-        RoutingOptions.addOption(RoadType.Toll);
+        routeToDisplay = mCarTollInfo; // Ambil data rute tol yang sudah jadi
       }
       else
       {
         price = mCarNoTollPriceValue;
-        // Perintahkan untuk menghitung ulang dengan opsi TOL DINONAKTIFKAN
-        RoutingOptions.removeOption(RoadType.Toll);
+        routeToDisplay = mCarNoTollInfo; // Ambil data rute non-tol yang sudah jadi
       }
 
       // Perbarui teks harga
       java.text.NumberFormat format = java.text.NumberFormat.getCurrencyInstance(new java.util.Locale("id", "ID"));
       mCarPrice.setText(format.format(price));
 
-      // Picu perhitungan ulang yang cepat agar rute di peta diperbarui
-      controller.rebuild();
+      // Tampilkan rute mobil yang dipilih secara instan
+      if (routeToDisplay != null)
+        controller.showCachedRoute(routeToDisplay, Router.Vehicle);
+
     }
     else if (mSelectedRouter == Router.Bicycle)
     {
-      // Cek apakah tipe router saat ini BUKAN Bicycle untuk menghindari build ulang yang tidak perlu.
-      if (controller.getLastRouterType() != Router.Bicycle)
-      {
-        // Atur tipe router ke motor. Method ini sudah otomatis memicu perhitungan ulang.
-        controller.setRouterType(Router.Bicycle);
-      }
+      // Tampilkan rute motor yang dipilih secara instan
+      if (mMotorcycleInfo != null)
+        controller.showCachedRoute(mMotorcycleInfo, Router.Bicycle);
     }
   }
 

--- a/app/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
+++ b/app/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
@@ -331,6 +331,31 @@ public class RoutingController
   {
     build();
   }
+
+  /**
+   * Instantly displays a pre-calculated route on the map without any recalculation.
+   * It manually sets the controller's state and tells the native engine to draw the route.
+   */
+  public void showCachedRoute(@NonNull RoutingInfo info, @NonNull Router router)
+  {
+    // 1. Set tipe router secara manual agar sesuai dengan rute yang akan ditampilkan
+    mLastRouterType = router;
+    Router.set(router);
+
+    // 2. "Suntikkan" data rute yang sudah jadi ke dalam cache controller
+    mCachedRoutingInfo = info;
+
+    // 3. Hapus rute lama dari peta
+    Framework.nativeRemoveRoute();
+
+    // 4. Atur state seolah-olah rute baru saja selesai dibangun
+    setBuildState(BuildState.BUILT);
+
+    // 5. Trik Kunci: Perintahkan engine untuk "mengikuti" rute (ini akan menggambarnya di peta),
+    //    lalu langsung batalkan mode "mengikuti" agar tidak masuk ke mode navigasi.
+    Framework.nativeFollowRoute();
+    Framework.nativeDisableFollowing();
+  }
   // ===================================================================
   // AKHIR DARI BLOK BARU
   // ===================================================================


### PR DESCRIPTION
## Summary
- add `showCachedRoute` to `RoutingController` to render cached routes without recalculation
- simplify `MwmActivity.updateRouteSelection` to display cached routes instantly

## Testing
- `./gradlew test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688db5bd5d908329aa7cf30e7b525f62