### PR TITLE
Ensure back from ride-hailing screens opens search

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1321,6 +1321,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onBackPressed()
   {
     resetRoutingController();
+    if (UiUtils.isVisible(mRoutingSummaryPanel) || UiUtils.isVisible(mConfirmPickupButton))
+    {
+      exitRideHailingMode();
+      showSearch("");
+      return;
+    }
     final RoutingController routingController = RoutingController.get();
     if (!closeBottomSheet(MAIN_MENU_ID) && !closeBottomSheet(LAYERS_MENU_ID) && !collapseNavMenu() && !closePlacePage()
         && !closeSearchToolbar(true, true) && !closeSidePanel() && !closePositionChooser()
@@ -2043,7 +2049,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private void exitRideHailingMode()
   {
     mIsInRideHailingMode = false;
+    mIsSelectingPickup = false;
+    mPickupPoint = null;
+    mCurrentPlacePageObject = null;
     setCalculationState(CalculationState.NONE);
+    UiUtils.hide(mConfirmPickupButton);
     UiUtils.hide(mRoutingSummaryPanel);
     UiUtils.hide(mRoutingProgressOverlay);
     mMapButtonsViewModel.setButtonsHidden(false);


### PR DESCRIPTION
## Summary
- Redirect back press from ride-hailing summary or selection screens to Search
- Reset ride-hailing state when leaving these screens

## Testing
- `./gradlew test` *(fails: Process 'bash' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688dc89cabc88329834f3e373676dc40