### PR TITLE
Consume routing summary touch events

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -630,6 +630,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mTollSwitch = mRoutingSummaryPanel.findViewById(R.id.switch_toll);
     mNoteEditText = mRoutingSummaryPanel.findViewById(R.id.et_note);
     mBitARideButton = mRoutingSummaryPanel.findViewById(R.id.btn_bit_a_ride);
+    mRoutingSummaryPanel.setOnTouchListener((v, event) -> true);
     mRoutingProgressOverlay = findViewById(R.id.routing_progress_overlay);
 
     if (!RoutingOptions.hasOption(RoadType.Dirty))

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -73,6 +73,8 @@
       android:layout_gravity="bottom"
       android:background="?colorSurface"
       android:orientation="vertical"
+      android:clickable="true"
+      android:focusable="true"
       android:elevation="12dp"
       android:padding="16dp"
       android:visibility="gone"


### PR DESCRIPTION
## Summary
- Make routing summary panel focusable and clickable to intercept taps
- Consume all touch events from routing summary panel

## Testing
- `./gradlew test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_688df2669b78832984fb0508cb7e9be1