### PR TITLE
Ganti switch pembayaran dengan tombol toggle

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -261,10 +261,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private TextView mMotorcyclePrice;
   private View mCarOption;
   private View mMotorcycleOption;
-  private SwitchMaterial mPaymentSwitch;
+  private com.google.android.material.button.MaterialButtonToggleGroup mPaymentToggle;
   private SwitchMaterial mTollSwitch;
   private TextInputEditText mNoteEditText;
   private com.google.android.material.button.MaterialButton mBitARideButton;
+  @NonNull private String mPaymentType = "Cash";
   private View mRoutingProgressOverlay;
   @Nullable private Router mSelectedRouter;
 
@@ -626,7 +627,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mMotorcyclePrice = mRoutingSummaryPanel.findViewById(R.id.tv_motorcycle_price);
     mCarOption = mRoutingSummaryPanel.findViewById(R.id.btn_use_car);
     mMotorcycleOption = mRoutingSummaryPanel.findViewById(R.id.btn_use_motorcycle);
-    mPaymentSwitch = mRoutingSummaryPanel.findViewById(R.id.switch_payment);
+    mPaymentToggle = mRoutingSummaryPanel.findViewById(R.id.toggle_payment);
     mTollSwitch = mRoutingSummaryPanel.findViewById(R.id.switch_toll);
     mNoteEditText = mRoutingSummaryPanel.findViewById(R.id.et_note);
     mBitARideButton = mRoutingSummaryPanel.findViewById(R.id.btn_bit_a_ride);
@@ -665,6 +666,15 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mTollSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
       // Update tampilan rute saat switch tol diubah
       updateRouteSelection();
+    });
+
+    mPaymentToggle.addOnButtonCheckedListener((group, checkedId, isChecked) -> {
+      if (!isChecked)
+        return;
+      if (checkedId == R.id.btn_cash)
+        mPaymentType = "Cash";
+      else if (checkedId == R.id.btn_qris)
+        mPaymentType = "QRIS";
     });
 
     mBitARideButton.setOnClickListener(v -> {
@@ -1949,7 +1959,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
             .format(mMotorcyclePriceValue));
     mTollSwitch.setChecked(false);
     mTollSwitch.setVisibility(View.GONE);
-    mPaymentSwitch.setChecked(false);
+    mPaymentToggle.check(R.id.btn_cash);
+    mPaymentType = "Cash";
     mNoteEditText.setText(null);
 
     // Atur pilihan default ke mobil saat panel pertama kali muncul

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -151,13 +151,24 @@
         android:layout_marginTop="8dp"
         android:gravity="center_vertical">
 
-      <com.google.android.material.switchmaterial.SwitchMaterial
-          android:id="@+id/switch_payment"
+      <com.google.android.material.button.MaterialButtonToggleGroup
+          android:id="@+id/toggle_payment"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:textOff="Cash"
-          android:textOn="QRIS"
-          android:showText="true" />
+          app:singleSelection="true">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_cash"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Cash" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_qris"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="QRIS" />
+      </com.google.android.material.button.MaterialButtonToggleGroup>
 
       <View
           android:layout_width="0dp"


### PR DESCRIPTION
## Ringkasan
- Ganti `SwitchMaterial` pembayaran dengan `MaterialButtonToggleGroup` berisi tombol "Cash" dan "QRIS".
- Gunakan `MaterialButtonToggleGroup` di `MwmActivity` dan tambahkan listener untuk menyimpan jenis pembayaran yang dipilih.

## Pengujian
- `./gradlew assembleDebug` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_688df381ad908329a51f1683633ea349