### PR TITLE
Pindah tombol back ke layar pickup

### DIFF
--- a/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -78,6 +78,12 @@ public class SearchFragment extends BaseMwmFragment implements SearchListener, C
     }
 
     @Override
+    protected boolean showBackButton()
+    {
+      return false;
+    }
+
+    @Override
     protected void onTextChanged(String query)
     {
       if (!isAdded())

--- a/app/src/main/res/layout/toolbar_search_controls.xml
+++ b/app/src/main/res/layout/toolbar_search_controls.xml
@@ -18,7 +18,8 @@
       app:srcCompat="?homeAsUpIndicator"
       android:scaleType="center"
       tools:src="@drawable/ic_down"
-      android:contentDescription="@string/back"/>
+      android:contentDescription="@string/back"
+      android:visibility="gone"/>
 
   <LinearLayout
       android:layout_width="0dp"
@@ -92,7 +93,7 @@
       android:id="@+id/voice_input"
       android:layout_width="?actionBarSize"
       android:layout_height="?actionBarSize"
-      android:layout_gravity="center_vertical"
+      android:layout_gravity="bottom"
       android:layout_weight="0"
       android:background="?attr/selectableItemBackgroundBorderless"
       android:contentDescription="@null"


### PR DESCRIPTION
## Ringkasan
- Hilangkan tombol kembali di toolbar pencarian dan biarkan kolom pencarian memenuhi sisi kiri.
- Posisikan tombol mikrofon sejajar dengan kolom destinasi.
- Kode pencarian kini tidak lagi menampilkan tombol kembali.

## Pengujian
- `./gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_688e132c54b083298f25a8522dd6be1a