### PR TITLE
Hapus pemanggilan updateLayerButton yang tidak digunakan

### DIFF
--- a/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
+++ b/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
@@ -383,7 +383,6 @@ public class MapButtonsController extends Fragment
     super.onResume();
     mSearchWheel.onResume();
     updateMenuBadge();
-    updateLayerButton();
     final WindowInsetUtils.PaddingInsetsListener insetsListener =
         new WindowInsetUtils.PaddingInsetsListener.Builder()
             .setInsetsTypeMask(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout())


### PR DESCRIPTION
## Ringkasan
- Hapus pemanggilan `updateLayerButton()` di `MapButtonsController.onResume()` karena tombol layer telah dihapus.

## Pengujian
- `./gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_688e4edd74a88329b7b258dd8f353e26