### PR TITLE
feat: tampilkan rute dari cache

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -2037,8 +2037,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (geometry != null)
     {
       Framework.nativeRemoveRoute();
-      // TODO: gambar ulang rute dari geometry tanpa perhitungan ulang
-      controller.rebuild();
+      Framework.nativeDisplayRouteFromGeometry(geometry);
     }
     else
     {

--- a/app/src/main/java/app/organicmaps/sdk/Framework.java
+++ b/app/src/main/java/app/organicmaps/sdk/Framework.java
@@ -193,6 +193,8 @@ public class Framework
 
   public static native void nativeRemoveRoute();
 
+  public static native void nativeDisplayRouteFromGeometry(@NonNull JunctionInfo[] points);
+
   public static native void nativeFollowRoute();
 
   public static native void nativeDisableFollowing();

--- a/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -1202,6 +1202,31 @@ JNIEXPORT void JNICALL Java_app_organicmaps_sdk_Framework_nativeRemoveRoute(JNIE
   frm()->GetRoutingManager().RemoveRoute(false /* deactivateFollowing */);
 }
 
+JNIEXPORT void JNICALL Java_app_organicmaps_sdk_Framework_nativeDisplayRouteFromGeometry(JNIEnv * env, jclass,
+                                                                                         jobjectArray jpoints)
+{
+  if (!jpoints)
+    return;
+
+  jsize const length = env->GetArrayLength(jpoints);
+  std::vector<geometry::PointWithAltitude> points;
+  points.reserve(length);
+
+  static jclass const pointClazz = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/routing/JunctionInfo");
+  static jfieldID const latField = jni::GetFieldID(env, pointClazz, "mLat", "D");
+  static jfieldID const lonField = jni::GetFieldID(env, pointClazz, "mLon", "D");
+
+  for (jsize i = 0; i < length; ++i)
+  {
+    jni::ScopedLocalRef<jobject> const jPoint(env, env->GetObjectArrayElement(jpoints, i));
+    double const lat = env->GetDoubleField(jPoint.get(), latField);
+    double const lon = env->GetDoubleField(jPoint.get(), lonField);
+    points.emplace_back(mercator::FromLatLon(lat, lon), geometry::kDefaultAltitudeMeters);
+  }
+
+  frm()->GetRoutingManager().DisplayRouteFromGeometry(points);
+}
+
 JNIEXPORT void JNICALL Java_app_organicmaps_sdk_Framework_nativeFollowRoute(JNIEnv * env, jclass)
 {
   frm()->GetRoutingManager().FollowRoute();


### PR DESCRIPTION
## Ringkasan
- tambahkan API native untuk menggambar rute dari array JunctionInfo
- panggil API baru pada `displayCachedRoute` agar pergantian kendaraan instan tanpa rebuild

## Pengujian
- `./gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68989a9013448329bfcd2d3853fa284a