### PR TITLE
Gunakan JNIEnv::GetFieldID di route geometry

### DIFF
--- a/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -1213,8 +1213,8 @@ JNIEXPORT void JNICALL Java_app_organicmaps_sdk_Framework_nativeDisplayRouteFrom
   points.reserve(length);
 
   static jclass const pointClazz = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/routing/JunctionInfo");
-  static jfieldID const latField = jni::GetFieldID(env, pointClazz, "mLat", "D");
-  static jfieldID const lonField = jni::GetFieldID(env, pointClazz, "mLon", "D");
+  static jfieldID const latField = env->GetFieldID(pointClazz, "mLat", "D");
+  static jfieldID const lonField = env->GetFieldID(pointClazz, "mLon", "D");
 
   for (jsize i = 0; i < length; ++i)
   {


### PR DESCRIPTION
## Ringkasan
- ganti jni::GetFieldID dengan env->GetFieldID untuk mLat dan mLon di nativeDisplayRouteFromGeometry
- pertahankan pointClazz yang diambil lewat jni::GetGlobalClassRef

## Pengujian
- `./gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_6898a564f84483298bfb34909b70f1c8