### PR TITLE
feat: tampilkan rute dari geometry

### DIFF
--- a/sdk/src/main/cpp/CMakeLists.txt
+++ b/sdk/src/main/cpp/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SRC
   app/organicmaps/sdk/routing/RouteRecommendationType.hpp
   app/organicmaps/sdk/routing/RoutingInfo.hpp
   app/organicmaps/sdk/routing/RoutingOptions.cpp
+  app/organicmaps/sdk/routing/DisplayRouteFromGeometry.cpp
   app/organicmaps/sdk/routing/SingleLaneInfo.hpp
   app/organicmaps/sdk/routing/TransitRouteInfo.hpp
   app/organicmaps/sdk/routing/TransitStepInfo.hpp

--- a/sdk/src/main/cpp/app/organicmaps/sdk/routing/DisplayRouteFromGeometry.cpp
+++ b/sdk/src/main/cpp/app/organicmaps/sdk/routing/DisplayRouteFromGeometry.cpp
@@ -1,0 +1,31 @@
+#include "map/routing_manager.hpp"
+#include "drape_frontend/route_shape.hpp"
+#include "drape/pointers.hpp"
+
+#include <mutex>
+#include <vector>
+
+using namespace std;
+
+void RoutingManager::DisplayRouteFromGeometry(vector<geometry::PointWithAltitude> const & points)
+{
+  if (points.size() < 2)
+    return;
+
+  auto subroute = make_unique_dp<df::Subroute>();
+  subroute->m_routeType = df::RouteType::Car;
+
+  vector<m2::PointD> poly;
+  poly.reserve(points.size());
+  for (auto const & p : points)
+    poly.emplace_back(p.GetPoint());
+  subroute->m_polyline = m2::PolylineD(move(poly));
+  subroute->AddStyle(df::SubrouteStyle(df::kRouteColor, df::kRouteOutlineColor));
+
+  auto const id =
+      m_drapeEngine.SafeCallWithResult(&df::DrapeEngine::AddSubroute,
+                                       df::SubrouteConstPtr(subroute.release()));
+  lock_guard<mutex> guard(m_drapeSubroutesMutex);
+  m_drapeSubroutes.push_back(id);
+}
+


### PR DESCRIPTION
## Ringkasan
- tambah implementasi `RoutingManager::DisplayRouteFromGeometry` untuk menggambar rute dari kumpulan titik
- daftarkan sumber baru pada CMake agar tersusun

## Pengujian
- `./gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_6898a6afd49c832993aa533873357fb7