### PR TITLE
Ensure DisplayRouteFromGeometry includes geometry header

### DIFF
--- a/sdk/src/main/cpp/app/organicmaps/sdk/routing/DisplayRouteFromGeometry.cpp
+++ b/sdk/src/main/cpp/app/organicmaps/sdk/routing/DisplayRouteFromGeometry.cpp
@@ -1,6 +1,7 @@
 #include "map/routing_manager.hpp"
 #include "drape_frontend/route_shape.hpp"
 #include "drape/pointers.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <mutex>
 #include <vector>


### PR DESCRIPTION
## Summary
- include `geometry/point_with_altitude.hpp` in DisplayRouteFromGeometry implementation

## Testing
- `./gradlew :sdk:assembleDebug` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_6898b3bd9084832990691eb7fa8cecaa