### PR TITLE
Expose routing manager wrapper for geometry display

### DIFF
--- a/sdk/src/main/cpp/CMakeLists.txt
+++ b/sdk/src/main/cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SRC
   app/organicmaps/sdk/routing/RouteMarkType.hpp
   app/organicmaps/sdk/routing/RoutePointInfo.hpp
   app/organicmaps/sdk/routing/RouteRecommendationType.hpp
+  app/organicmaps/sdk/routing/RoutingManager.hpp
   app/organicmaps/sdk/routing/RoutingInfo.hpp
   app/organicmaps/sdk/routing/RoutingOptions.cpp
   app/organicmaps/sdk/routing/DisplayRouteFromGeometry.cpp

--- a/sdk/src/main/cpp/app/organicmaps/sdk/routing/DisplayRouteFromGeometry.cpp
+++ b/sdk/src/main/cpp/app/organicmaps/sdk/routing/DisplayRouteFromGeometry.cpp
@@ -1,4 +1,4 @@
-#include "map/routing_manager.hpp"
+#include "RoutingManager.hpp"
 #include "drape_frontend/route_shape.hpp"
 #include "drape/pointers.hpp"
 #include "geometry/point_with_altitude.hpp"

--- a/sdk/src/main/cpp/app/organicmaps/sdk/routing/RoutingManager.hpp
+++ b/sdk/src/main/cpp/app/organicmaps/sdk/routing/RoutingManager.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "map/routing_manager.hpp"


### PR DESCRIPTION
## Summary
- add SDK wrapper header for RoutingManager
- include wrapper in DisplayRouteFromGeometry
- register new header in CMakeLists

## Testing
- `./gradlew assembleDebug` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_6898ba1e25388329a91e715c489d8e45