### PR TITLE
feat: add ride mesh codec and tests

### DIFF
--- a/app/src/main/java/app/organicmaps/bitride/mesh/RideMeshCodec.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/RideMeshCodec.kt
@@ -1,0 +1,119 @@
+package app.organicmaps.bitride.mesh
+
+import java.util.Locale
+
+/**
+ * Channel: #bitride (public)
+ * Payload (ASCII, <=352 char):
+ * BR1|r=C;h=<64HEX>;v=<m|c>;p=<lat,lon>;d=<lat,lon>;pr=<int>;t=<0|1>;tr=<int>;ud=<int>;ps=<int>;ng=<int>;ac=<int>
+ * RP1|r=D;h=<64HEX>;v=<m|c>;pr=<int>;ok=<0|1>
+ * CF1|h=<64HEX>;ok=1
+ */
+object RideMeshCodec {
+  private const val MAX_LEN = 352
+  private val HEX64 = Regex("^[0-9a-fA-F]{64}$")
+  private val LOCALE = Locale.US
+
+  fun isRideMessage(raw: String) =
+    raw.startsWith("BR1|") || raw.startsWith("RP1|") || raw.startsWith("CF1|")
+
+  fun kindOf(raw: String) = when {
+    raw.startsWith("BR1|") -> RideMessageKind.REQUEST
+    raw.startsWith("RP1|") -> RideMessageKind.REPLY
+    raw.startsWith("CF1|") -> RideMessageKind.CONFIRM
+    else -> RideMessageKind.UNKNOWN
+  }
+
+  fun encodeRequest(x: RideRequest): String {
+    require(x.hashHex.matches(HEX64)) { "hashHex must be 64 hex" }
+    val p = formatPoint(x.pickup)
+    val d = formatPoint(x.destination)
+    val s = buildString {
+      append("BR1|r=C;")
+      append("h=${x.hashHex};")
+      append("v=${x.vehicle.code};")
+      append("p=$p;")
+      append("d=$d;")
+      append("pr=${x.priceRp};")
+      append("t=${if (x.toll) 1 else 0};")
+      append("tr=${x.totalRides};")
+      append("ud=${x.uniqueDrivers};")
+      append("ps=${x.positive};")
+      append("ng=${x.negative};")
+      append("ac=${x.askCancel}")
+    }
+    require(s.length <= MAX_LEN) { "payload too long (${s.length})" }
+    return s
+  }
+
+  fun encodeDriverReply(x: DriverReply): String {
+    require(x.hashHex.matches(HEX64)) { "hashHex must be 64 hex" }
+    val s = "RP1|r=D;h=${x.hashHex};v=${x.vehicle.code};pr=${x.priceRp};ok=${if (x.ok) 1 else 0}"
+    require(s.length <= MAX_LEN) { "payload too long (${s.length})" }
+    return s
+  }
+
+  fun encodeConfirm(x: RideConfirm): String {
+    require(x.hashHex.matches(HEX64)) { "hashHex must be 64 hex" }
+    val s = "CF1|h=${x.hashHex};ok=${if (x.ok) 1 else 0}"
+    require(s.length <= MAX_LEN) { "payload too long (${s.length})" }
+    return s
+  }
+
+  fun decodeRequest(raw: String): RideRequest? {
+    if (!raw.startsWith("BR1|")) return null
+    val map = toMap(raw.removePrefix("BR1|"))
+    val h = map["h"] ?: return null
+    if (!HEX64.matches(h)) return null
+    val v = map["v"]?.firstOrNull()?.let { VehicleType.fromCode(it) } ?: return null
+    val p = map["p"]?.let { parsePoint(it) } ?: return null
+    val d = map["d"]?.let { parsePoint(it) } ?: return null
+    val pr = map["pr"]?.toIntOrNull() ?: return null
+    val t = map["t"] == "1"
+    val tr = map["tr"]?.toIntOrNull() ?: 0
+    val ud = map["ud"]?.toIntOrNull() ?: 0
+    val ps = map["ps"]?.toIntOrNull() ?: 0
+    val ng = map["ng"]?.toIntOrNull() ?: 0
+    val ac = map["ac"]?.toIntOrNull() ?: 0
+    return RideRequest('C', h, v!!, p, d, pr, t, tr, ud, ps, ng, ac)
+  }
+
+  fun decodeDriverReply(raw: String): DriverReply? {
+    if (!raw.startsWith("RP1|")) return null
+    val map = toMap(raw.removePrefix("RP1|"))
+    val h = map["h"] ?: return null
+    if (!HEX64.matches(h)) return null
+    val v = map["v"]?.firstOrNull()?.let { VehicleType.fromCode(it) } ?: return null
+    val pr = map["pr"]?.toIntOrNull() ?: return null
+    val ok = map["ok"] == "1"
+    return DriverReply('D', h, v!!, pr, ok)
+  }
+
+  fun decodeConfirm(raw: String): RideConfirm? {
+    if (!raw.startsWith("CF1|")) return null
+    val map = toMap(raw.removePrefix("CF1|"))
+    val h = map["h"] ?: return null
+    if (!HEX64.matches(h)) return null
+    val ok = map["ok"] == "1"
+    return RideConfirm(h, ok)
+  }
+
+  private fun toMap(body: String): Map<String, String> =
+    body.split(';').mapNotNull { s ->
+      val i = s.indexOf('=')
+      if (i <= 0) null else s.substring(0, i) to s.substring(i + 1)
+    }.toMap()
+
+  private fun parsePoint(s: String): GeoPoint {
+    val parts = s.split(',')
+    require(parts.size == 2) { "point must be lat,lon" }
+    val lat = parts[0].toDoubleOrNull() ?: error("lat invalid")
+    val lon = parts[1].toDoubleOrNull() ?: error("lon invalid")
+    return GeoPoint(lat, lon)
+  }
+
+  private fun formatPoint(p: GeoPoint): String {
+    fun fmt(d: Double) = String.format(LOCALE, "%.6f", d).trimEnd('0').trimEnd('.')
+    return "${fmt(p.lat)},${fmt(p.lon)}"
+  }
+}

--- a/app/src/main/java/app/organicmaps/bitride/mesh/RideMeshListener.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/RideMeshListener.kt
@@ -1,0 +1,7 @@
+package app.organicmaps.bitride.mesh
+
+interface RideMeshListener {
+  fun onRideRequestFromCustomer(req: RideRequest, senderPeerId: String)
+  fun onDriverReply(resp: DriverReply, senderPeerId: String)
+  fun onConfirm(confirm: RideConfirm, senderPeerId: String)
+}

--- a/app/src/main/java/app/organicmaps/bitride/mesh/RideMessageModels.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/RideMessageModels.kt
@@ -1,0 +1,38 @@
+package app.organicmaps.bitride.mesh
+
+enum class RideMessageKind { REQUEST, REPLY, CONFIRM, UNKNOWN }
+
+enum class VehicleType(val code: Char) {
+  MOTOR('m'), CAR('c');
+  companion object { fun fromCode(c: Char) = entries.firstOrNull { it.code == c } }
+}
+
+data class GeoPoint(val lat: Double, val lon: Double)
+
+data class RideRequest(
+  val role: Char = 'C',
+  val hashHex: String,
+  val vehicle: VehicleType,
+  val pickup: GeoPoint,
+  val destination: GeoPoint,
+  val priceRp: Int,
+  val toll: Boolean,
+  val totalRides: Int,
+  val uniqueDrivers: Int,
+  val positive: Int,
+  val negative: Int,
+  val askCancel: Int
+)
+
+data class DriverReply(
+  val role: Char = 'D',
+  val hashHex: String,
+  val vehicle: VehicleType,
+  val priceRp: Int,
+  val ok: Boolean
+)
+
+data class RideConfirm(
+  val hashHex: String,
+  val ok: Boolean = true
+)

--- a/app/src/test/java/app/organicmaps/bitride/mesh/RideMeshCodecTest.kt
+++ b/app/src/test/java/app/organicmaps/bitride/mesh/RideMeshCodecTest.kt
@@ -1,0 +1,42 @@
+package app.organicmaps.bitride.mesh
+
+import org.junit.Test
+import kotlin.test.*
+
+class RideMeshCodecTest {
+  private val H = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+  @Test fun encodeDecodeRequest() {
+    val req = RideRequest(
+      hashHex = H, vehicle = VehicleType.MOTOR,
+      pickup = GeoPoint(-6.175392,106.827153),
+      destination = GeoPoint(-6.121435,106.774124),
+      priceRp = 25000, toll = false,
+      totalRides = 10, uniqueDrivers = 7, positive = 9, negative = 0, askCancel = 1
+    )
+    val s = RideMeshCodec.encodeRequest(req)
+    assertTrue(s.startsWith("BR1|"))
+    assertTrue(s.length <= 352, "len=${s.length}")
+    val p = RideMeshCodec.decodeRequest(s)!!
+    assertEquals(req.hashHex, p.hashHex)
+    assertEquals(req.vehicle, p.vehicle)
+    assertEquals(req.priceRp, p.priceRp)
+  }
+
+  @Test fun encodeDecodeReply() {
+    val r = DriverReply('D', H, VehicleType.CAR, 40000, ok = true)
+    val s = RideMeshCodec.encodeDriverReply(r)
+    val p = RideMeshCodec.decodeDriverReply(s)!!
+    assertEquals(r.vehicle, p.vehicle)
+    assertEquals(40000, p.priceRp)
+    assertTrue(p.ok)
+  }
+
+  @Test fun encodeDecodeConfirm() {
+    val c = RideConfirm(H, true)
+    val s = RideMeshCodec.encodeConfirm(c)
+    val p = RideMeshCodec.decodeConfirm(s)!!
+    assertEquals(H, p.hashHex)
+    assertTrue(p.ok)
+  }
+}


### PR DESCRIPTION
## Summary
- add ride mesh message models
- add ride mesh codec and listener
- add unit tests for ride mesh codec

## Testing
- `./gradlew :app:testGoogleDebugUnitTest` *(fails: resource xml/network_security_config not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5745264883298106bff5e7b27f4c