### PR TITLE
Align compile SDK and Java versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -261,9 +261,11 @@ android {
 
   compileOptions {
     coreLibraryDesugaringEnabled = true
-
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
+  }
+  kotlinOptions {
+    jvmTarget = "11"
   }
 }
 

--- a/bitchatcore/build.gradle.kts
+++ b/bitchatcore/build.gradle.kts
@@ -52,6 +52,4 @@ dependencies {
   implementation("org.bouncycastle:bcprov-jdk15on:1.70")
   implementation("com.google.crypto.tink:tink-android:1.12.0")
   implementation("org.lz4:lz4-java:1.8.0")
-  // (opsional) logging
-  implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 propMinSdkVersion=21
 propTargetSdkVersion=36
-propCompileSdkVersion=36
+propCompileSdkVersion=35
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2048m -Xms512m


### PR DESCRIPTION
## Summary
- remove optional lifecycle dependency from bitchatcore
- target Java 11 for app module
- set project compileSdk to Android 15 (API 35)

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_689badecef5083299ed503c7c98651ad