### PR TITLE
Use non-exported broadcast receivers

### DIFF
--- a/app/src/main/java/app/organicmaps/sdk/settings/StoragePathManager.java
+++ b/app/src/main/java/app/organicmaps/sdk/settings/StoragePathManager.java
@@ -11,6 +11,7 @@ import android.os.storage.StorageVolume;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import app.organicmaps.R;
 import app.organicmaps.sdk.Framework;
 import app.organicmaps.sdk.downloader.MapManager;
@@ -81,7 +82,8 @@ public class StoragePathManager
       }
     };
 
-    mContext.registerReceiver(mInternalReceiver, getMediaChangesIntentFilter());
+    ContextCompat.registerReceiver(mContext, mInternalReceiver,
+                                  getMediaChangesIntentFilter(), ContextCompat.RECEIVER_NOT_EXPORTED);
   }
 
   private static IntentFilter getMediaChangesIntentFilter()

--- a/app/src/main/java/app/organicmaps/sdk/util/BatteryState.java
+++ b/app/src/main/java/app/organicmaps/sdk/util/BatteryState.java
@@ -30,7 +30,8 @@ public final class BatteryState
     IntentFilter filter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
     // Because it's a sticky intent, you don't need to register a BroadcastReceiver
     // by simply calling registerReceiver passing in null
-    Intent batteryStatus = context.getApplicationContext().registerReceiver(null, filter);
+    Intent batteryStatus = context.getApplicationContext()
+                               .registerReceiver(null, filter, Context.RECEIVER_NOT_EXPORTED);
     if (batteryStatus == null)
       return new State(0, CHARGING_STATUS_UNKNOWN);
 


### PR DESCRIPTION
## Ringkasan
- Gunakan `ContextCompat.registerReceiver` dengan flag `RECEIVER_NOT_EXPORTED` untuk pemantauan penyimpanan eksternal.
- Tambahkan flag `Context.RECEIVER_NOT_EXPORTED` saat mengambil status baterai.

## Pengujian
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 lint` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_689e121a04dc83299f91ca74a86f27bb