### PR TITLE
Batasi tipe foreground service pada connected device dan data sync

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,9 +43,8 @@
   <uses-permission
       android:name="android.permission.FOREGROUND_SERVICE"
       tools:targetApi="p" />
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
   <!-- Android 13+ notifications runtime permission -->
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -414,13 +413,11 @@
 
     <service
         android:name=".routing.NavigationService"
-        android:foregroundServiceType="location"
         android:exported="false"
         android:enabled="true"
         android:stopWithTask="false"/>
 
     <service android:name=".location.TrackRecordingService"
-        android:foregroundServiceType="location"
         android:exported="false"
         android:enabled="true"
         android:stopWithTask="false" />

--- a/app/src/main/java/app/organicmaps/location/TrackRecordingService.java
+++ b/app/src/main/java/app/organicmaps/location/TrackRecordingService.java
@@ -9,7 +9,6 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ServiceInfo;
 import android.location.Location;
 import android.os.Build;
 import android.os.IBinder;
@@ -163,12 +162,8 @@ public class TrackRecordingService extends Service implements LocationListener
     }
 
     Logger.i(TAG, "Starting Track Recording Foreground service");
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-      ServiceCompat.startForeground(this, TrackRecordingService.TRACK_REC_NOTIFICATION_ID,
-                                    getNotificationBuilder(this).build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
-    else
-      ServiceCompat.startForeground(this, TrackRecordingService.TRACK_REC_NOTIFICATION_ID,
-                                    getNotificationBuilder(this).build(), 0);
+    ServiceCompat.startForeground(this, TrackRecordingService.TRACK_REC_NOTIFICATION_ID,
+                                  getNotificationBuilder(this).build());
 
     final LocationHelper locationHelper = MwmApplication.from(this).getLocationHelper();
 

--- a/app/src/main/java/app/organicmaps/routing/NavigationService.java
+++ b/app/src/main/java/app/organicmaps/routing/NavigationService.java
@@ -12,7 +12,6 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ServiceInfo;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
@@ -226,11 +225,7 @@ public class NavigationService extends Service implements LocationListener
     }
 
     Logger.i(TAG, "Starting Navigation Foreground service");
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-      ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build(),
-                                    ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
-    else
-      ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build(), 0);
+    ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build());
 
     final LocationHelper locationHelper = MwmApplication.from(this).getLocationHelper();
 


### PR DESCRIPTION
## Ringkasan
- Hapus deklarasi tipe foreground service lokasi dan hilangkan permisi terkait
- Gunakan hanya `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_CONNECTED_DEVICE`, dan `FOREGROUND_SERVICE_DATA_SYNC`
- Biarkan MeshService memakai kombinasi `connectedDevice|dataSync`

## Pengujian
- `./gradlew assembleDebug -Dorg.gradle.java.home=$JAVA_HOME` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_689e154166a08329b559d79559b49613