### PR TITLE
Cek izin BLE sebelum memulai mesh

### DIFF
--- a/app/src/main/java/app/organicmaps/bitride/mesh/MeshDebugActivity.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/MeshDebugActivity.kt
@@ -181,7 +181,11 @@ class MeshDebugActivity : AppCompatActivity(), RideMeshListener {
     if (code == REQ_BLE) {
       if (BlePermissionHelper.hasAll(this)) {
         toast("Permissions granted. Starting mesh…")
-        startAndBindService()
+        if (svc != null) {
+          svc?.startMesh("#bitride")
+        } else {
+          startAndBindService()
+        }
       } else {
         if (BlePermissionHelper.somePermissionPermanentlyDenied(this)) {
           toast("Izin ditolak permanen. Buka Settings untuk mengaktifkan.")

--- a/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
@@ -21,6 +21,13 @@ class MeshService : Service() {
     const val EXTRA_MISSING_PERMS = "app.organicmaps.bitride.mesh.EXTRA_MISSING_PERMS"
 
     fun start(context: Context) {
+      val missing = BlePermissionHelper.missingPermissions(context)
+      if (missing.isNotEmpty()) {
+        context.sendBroadcast(Intent(ACTION_PERMS_NEEDED).apply {
+          putExtra(EXTRA_MISSING_PERMS, missing.toTypedArray())
+        })
+        return
+      }
       context.startService(Intent(context, MeshService::class.java))
     }
 
@@ -98,6 +105,13 @@ class MeshService : Service() {
 
   fun startMesh(channel: String) {
     this.channel = channel
+    val missing = BlePermissionHelper.missingPermissions(this)
+    if (missing.isNotEmpty()) {
+      sendBroadcast(Intent(ACTION_PERMS_NEEDED).apply {
+        putExtra(EXTRA_MISSING_PERMS, missing.toTypedArray())
+      })
+      return
+    }
     mesh?.startServices()
   }
 


### PR DESCRIPTION
## Ringkasan
- Cek izin BLE saat start service dan broadcast `ACTION_PERMS_NEEDED` bila ada izin yang hilang.
- Aktivitas memanggil `startMesh` lagi setelah izin diberikan.

## Pengujian
- `./gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_689e181fdeb88329849fc9a5e5fcfd40