### PR TITLE
Handle nullable sender IDs in mesh listener

### DIFF
--- a/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
@@ -65,18 +65,24 @@ class MeshService : Service() {
             if (!RideMeshCodec.isRideMessage(raw)) return
             when (RideMeshCodec.kindOf(raw)) {
               RideMessageKind.REQUEST -> {
-                RideMeshCodec.decodeRequest(raw)?.let {
-                  listener?.onRideRequestFromCustomer(it, message.senderPeerID)
+                RideMeshCodec.decodeRequest(raw)?.let { req ->
+                  message.senderPeerID?.let { sender ->
+                    listener?.onRideRequestFromCustomer(req, sender)
+                  }
                 }
               }
               RideMessageKind.REPLY -> {
-                RideMeshCodec.decodeDriverReply(raw)?.let {
-                  listener?.onDriverReply(it, message.senderPeerID)
+                RideMeshCodec.decodeDriverReply(raw)?.let { reply ->
+                  message.senderPeerID?.let { sender ->
+                    listener?.onDriverReply(reply, sender)
+                  }
                 }
               }
               RideMessageKind.CONFIRM -> {
-                RideMeshCodec.decodeConfirm(raw)?.let {
-                  listener?.onConfirm(it, message.senderPeerID)
+                RideMeshCodec.decodeConfirm(raw)?.let { confirm ->
+                  message.senderPeerID?.let { sender ->
+                    listener?.onConfirm(confirm, sender)
+                  }
                 }
               }
               else -> {}


### PR DESCRIPTION
## Summary
- avoid passing nullable senderPeerID to listener callbacks

## Testing
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 :app:compileFdroidDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0e1ed574832988010e40775920fa