### PR TITLE
Handle nullable sender IDs and specify FGS types

### DIFF
--- a/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
@@ -65,18 +65,24 @@ class MeshService : Service() {
             if (!RideMeshCodec.isRideMessage(raw)) return
             when (RideMeshCodec.kindOf(raw)) {
               RideMessageKind.REQUEST -> {
-                RideMeshCodec.decodeRequest(raw)?.let {
-                  listener?.onRideRequestFromCustomer(it, message.senderPeerID)
+                RideMeshCodec.decodeRequest(raw)?.let { req ->
+                  message.senderPeerID?.let { sender ->
+                    listener?.onRideRequestFromCustomer(req, sender)
+                  }
                 }
               }
               RideMessageKind.REPLY -> {
-                RideMeshCodec.decodeDriverReply(raw)?.let {
-                  listener?.onDriverReply(it, message.senderPeerID)
+                RideMeshCodec.decodeDriverReply(raw)?.let { reply ->
+                  message.senderPeerID?.let { sender ->
+                    listener?.onDriverReply(reply, sender)
+                  }
                 }
               }
               RideMessageKind.CONFIRM -> {
-                RideMeshCodec.decodeConfirm(raw)?.let {
-                  listener?.onConfirm(it, message.senderPeerID)
+                RideMeshCodec.decodeConfirm(raw)?.let { confirm ->
+                  message.senderPeerID?.let { sender ->
+                    listener?.onConfirm(confirm, sender)
+                  }
                 }
               }
               else -> {}

--- a/app/src/main/java/app/organicmaps/location/TrackRecordingService.java
+++ b/app/src/main/java/app/organicmaps/location/TrackRecordingService.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.location.Location;
 import android.os.Build;
 import android.os.IBinder;
+import android.content.pm.ServiceInfo;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresPermission;
@@ -162,8 +163,13 @@ public class TrackRecordingService extends Service implements LocationListener
     }
 
     Logger.i(TAG, "Starting Track Recording Foreground service");
-    ServiceCompat.startForeground(this, TrackRecordingService.TRACK_REC_NOTIFICATION_ID,
-                                  getNotificationBuilder(this).build());
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+      ServiceCompat.startForeground(this, TrackRecordingService.TRACK_REC_NOTIFICATION_ID,
+                                    getNotificationBuilder(this).build(),
+                                    ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
+    else
+      ServiceCompat.startForeground(this, TrackRecordingService.TRACK_REC_NOTIFICATION_ID,
+                                    getNotificationBuilder(this).build(), 0);
 
     final LocationHelper locationHelper = MwmApplication.from(this).getLocationHelper();
 

--- a/app/src/main/java/app/organicmaps/routing/NavigationService.java
+++ b/app/src/main/java/app/organicmaps/routing/NavigationService.java
@@ -17,6 +17,7 @@ import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.os.Build;
 import android.os.IBinder;
+import android.content.pm.ServiceInfo;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresPermission;
@@ -225,7 +226,13 @@ public class NavigationService extends Service implements LocationListener
     }
 
     Logger.i(TAG, "Starting Navigation Foreground service");
-    ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build());
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+      ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID,
+                                    getNotificationBuilder(this).build(),
+                                    ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
+    else
+      ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID,
+                                    getNotificationBuilder(this).build(), 0);
 
     final LocationHelper locationHelper = MwmApplication.from(this).getLocationHelper();
 


### PR DESCRIPTION
## Summary
- avoid passing nullable senderPeerID to listener callbacks
- specify foreground service types when starting Navigation and Track Recording services

## Testing
- `ANDROID_SDK_ROOT=$PWD/sdk ./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 :app:compileFdroidDebugJavaWithJavac` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_689e0e1ed574832988010e40775920fa