### PR TITLE
Enable channel message display in mesh debug UI

### DIFF
--- a/app/src/main/java/app/organicmaps/bitride/mesh/MeshDebugActivity.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/MeshDebugActivity.kt
@@ -197,7 +197,11 @@ class MeshDebugActivity : AppCompatActivity(), RideMeshListener {
     }
   }
 
-  private fun addLine(s: String) { msgs.add(0, s); list.notifyDataSetChanged() }
+  private fun addLine(s: String) {
+    msgs.add(0, s)
+    list.notifyDataSetChanged()
+    toast(s)
+  }
   private fun toast(s: String) = Toast.makeText(this, s, Toast.LENGTH_SHORT).show()
 
   // ------- RideMeshListener --------
@@ -209,5 +213,9 @@ class MeshDebugActivity : AppCompatActivity(), RideMeshListener {
   }
   override fun onConfirm(confirm: RideConfirm, senderPeerId: String) {
     addLine("CF1 from ${senderPeerId.takeLast(6)} ok=${confirm.ok}")
+  }
+
+  override fun onChannelMessage(text: String, senderPeerId: String) {
+    addLine("CH from ${senderPeerId.takeLast(6)}: $text")
   }
 }

--- a/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
@@ -63,30 +63,28 @@ class MeshService : Service() {
         delegate = object : BluetoothMeshDelegate {
           override fun didReceiveMessage(message: BitchatMessage) {
             val raw = message.content
-            if (!RideMeshCodec.isRideMessage(raw)) return
-            when (RideMeshCodec.kindOf(raw)) {
-              RideMessageKind.REQUEST -> {
-                RideMeshCodec.decodeRequest(raw)?.let { req ->
-                  message.senderPeerID?.let { sender ->
+            val sender = message.senderPeerID ?: return
+            if (RideMeshCodec.isRideMessage(raw)) {
+              when (RideMeshCodec.kindOf(raw)) {
+                RideMessageKind.REQUEST -> {
+                  RideMeshCodec.decodeRequest(raw)?.let { req ->
                     listener?.onRideRequestFromCustomer(req, sender)
                   }
                 }
-              }
-              RideMessageKind.REPLY -> {
-                RideMeshCodec.decodeDriverReply(raw)?.let { reply ->
-                  message.senderPeerID?.let { sender ->
+                RideMessageKind.REPLY -> {
+                  RideMeshCodec.decodeDriverReply(raw)?.let { reply ->
                     listener?.onDriverReply(reply, sender)
                   }
                 }
-              }
-              RideMessageKind.CONFIRM -> {
-                RideMeshCodec.decodeConfirm(raw)?.let { confirm ->
-                  message.senderPeerID?.let { sender ->
+                RideMessageKind.CONFIRM -> {
+                  RideMeshCodec.decodeConfirm(raw)?.let { confirm ->
                     listener?.onConfirm(confirm, sender)
                   }
                 }
+                else -> {}
               }
-              else -> {}
+            } else {
+              listener?.onChannelMessage(raw, sender)
             }
           }
 

--- a/app/src/main/java/app/organicmaps/bitride/mesh/RideMeshListener.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/RideMeshListener.kt
@@ -4,4 +4,5 @@ interface RideMeshListener {
   fun onRideRequestFromCustomer(req: RideRequest, senderPeerId: String)
   fun onDriverReply(resp: DriverReply, senderPeerId: String)
   fun onConfirm(confirm: RideConfirm, senderPeerId: String)
+  fun onChannelMessage(text: String, senderPeerId: String)
 }


### PR DESCRIPTION
## Summary
- handle non-ride channel messages in `MeshService` and propagate to UI
- extend `RideMeshListener` with `onChannelMessage`
- show received channel messages in `MeshDebugActivity`
- pop up toast notifications for each received mesh message so they are visible without opening the log

## Testing
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 lint` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c488a2c8329a112e1e484ff6691