### PR TITLE
Tampilkan notifikasi saat pesan BLE mesh diterima

### DIFF
--- a/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
@@ -41,6 +41,7 @@ class MeshService : Service() {
   private var mesh: BluetoothMeshService? = null
   private var listener: RideMeshListener? = null
   private var channel: String? = null
+  private val notifier by lazy { RideNotificationManager(this) }
 
   inner class MeshBinder : Binder() {
     val service: MeshService
@@ -69,22 +70,35 @@ class MeshService : Service() {
                 RideMessageKind.REQUEST -> {
                   RideMeshCodec.decodeRequest(raw)?.let { req ->
                     listener?.onRideRequestFromCustomer(req, sender)
+                    notifier.show(
+                      "BR1 dari ${sender.takeLast(6)}",
+                      "Rp${req.priceRp} ${req.vehicle}"
+                    )
                   }
                 }
                 RideMessageKind.REPLY -> {
                   RideMeshCodec.decodeDriverReply(raw)?.let { reply ->
                     listener?.onDriverReply(reply, sender)
+                    notifier.show(
+                      "RP1 dari ${sender.takeLast(6)}",
+                      "Rp${reply.priceRp} ok=${reply.ok}"
+                    )
                   }
                 }
                 RideMessageKind.CONFIRM -> {
                   RideMeshCodec.decodeConfirm(raw)?.let { confirm ->
                     listener?.onConfirm(confirm, sender)
+                    notifier.show(
+                      "CF1 dari ${sender.takeLast(6)}",
+                      "ok=${confirm.ok}"
+                    )
                   }
                 }
                 else -> {}
               }
             } else {
               listener?.onChannelMessage(raw, sender)
+              notifier.show("CH dari ${sender.takeLast(6)}", raw)
             }
           }
 

--- a/app/src/main/java/app/organicmaps/bitride/mesh/RideNotificationManager.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/RideNotificationManager.kt
@@ -1,0 +1,41 @@
+package app.organicmaps.bitride.mesh
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+
+/**
+ * Menampilkan notifikasi sederhana untuk pesan mesh yang diterima.
+ */
+class RideNotificationManager(private val context: Context) {
+  companion object {
+    private const val CHANNEL_ID = "ride_mesh_messages"
+  }
+
+  private val nm = NotificationManagerCompat.from(context)
+
+  init {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val channel = NotificationChannel(
+        CHANNEL_ID,
+        "Ride Mesh Messages",
+        NotificationManager.IMPORTANCE_DEFAULT
+      )
+      val sys = context.getSystemService(NotificationManager::class.java)
+      sys?.createNotificationChannel(channel)
+    }
+  }
+
+  fun show(title: String, text: String) {
+    val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+      .setSmallIcon(android.R.drawable.ic_dialog_info)
+      .setContentTitle(title)
+      .setContentText(text)
+      .setAutoCancel(true)
+      .build()
+    nm.notify((System.currentTimeMillis() and 0xFFFFFF).toInt(), notification)
+  }
+}


### PR DESCRIPTION
## Ringkasan
- Tambah `RideNotificationManager` sederhana untuk menampilkan notifikasi pesan mesh
- Gunakan notifier di `MeshService` agar setiap pesan (BR1, RP1, CF1, dan channel) memicu notifikasi dengan isi pesan

## Pengujian
- `./gradlew :app:assembleDebug` *(gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_689f58cd5d908329bb400da7be58d4a3