### PR TITLE
Jalankan update UI MeshDebugActivity di main thread

### DIFF
--- a/app/src/main/java/app/organicmaps/bitride/mesh/MeshDebugActivity.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/MeshDebugActivity.kt
@@ -198,11 +198,15 @@ class MeshDebugActivity : AppCompatActivity(), RideMeshListener {
   }
 
   private fun addLine(s: String) {
-    msgs.add(0, s)
-    list.notifyDataSetChanged()
-    toast(s)
+    runOnUiThread {
+      msgs.add(0, s)
+      list.notifyDataSetChanged()
+      toast(s)
+    }
   }
-  private fun toast(s: String) = Toast.makeText(this, s, Toast.LENGTH_SHORT).show()
+  private fun toast(s: String) = runOnUiThread {
+    Toast.makeText(this, s, Toast.LENGTH_SHORT).show()
+  }
 
   // ------- RideMeshListener --------
   override fun onRideRequestFromCustomer(req: RideRequest, senderPeerId: String) {


### PR DESCRIPTION
## Ringkasan
- Bungkus logika `addLine` dengan `runOnUiThread` agar penambahan pesan dan notifikasi toast berjalan di main thread.
- Panggilan `toast` kini juga menggunakan `runOnUiThread` sehingga aman dari thread background.

## Pengujian
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` (gagal: Build file '/workspace/organic-maps-ride/build.gradle' line: 16, Process 'command 'bash'' finished with non-zero exit value 127)

------
https://chatgpt.com/codex/tasks/task_e_689f644db2d08329b5db00114472130a