### PR TITLE
Ensure Noise session before sending private messages

### DIFF
--- a/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/MeshService.kt
@@ -146,7 +146,20 @@ class MeshService : Service() {
     if (ch != null) mesh?.sendMessage(text, channel = ch)
   }
 
+  private fun ensureNoiseSession(peerId: String) {
+    mesh?.sendBroadcastAnnounce()
+    mesh?.broadcastNoiseIdentityAnnouncement()
+    if (mesh?.hasEstablishedSession(peerId) != true) {
+      mesh?.sendHandshakeRequest(peerId, 0u)
+    }
+  }
+
   fun sendPrivateMessage(peerId: String, text: String) {
+    ensureNoiseSession(peerId)
+    if (mesh?.hasEstablishedSession(peerId) != true) {
+      notifier.show("Gagal mengirim", "Handshake belum selesai")
+      return
+    }
     mesh?.sendPrivateMessage(text, peerId, peerId)
   }
 


### PR DESCRIPTION
## Summary
- add helper to announce and start Noise handshake before messaging
- notify user when handshake isn't established yet

## Testing
- `./gradlew test -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_689f7559289c8329a83435ba5e73cc67