### PR TITLE
feat: tampilkan permintaan ride di driver lounge

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -737,9 +737,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
       GeoPoint pickup = new GeoPoint(startPoint.getLat(), startPoint.getLon());
       GeoPoint destination = new GeoPoint(endPoint.getLat(), endPoint.getLon());
       String hash = sha256Hex(mMeshService.getPeerId());
+      String pickupName = startPoint.getName();
+      String destinationName = endPoint.getName();
+      String note = mNoteEditText.getText() == null ? "" : mNoteEditText.getText().toString();
       RideRequest req = new RideRequest('C', hash, vehicle, pickup, destination, price,
                                         mTollSwitch.isChecked(), 0, 0, 0, 0, 0,
-                                        mPaymentType, mNoteEditText.getText() == null ? "" : mNoteEditText.getText().toString());
+                                        mPaymentType, note, pickupName, destinationName);
       mMeshService.sendChannelMessage(RideMeshCodec.encodeRequest(req));
       Toast.makeText(this, "Permintaan tumpangan dikirim", Toast.LENGTH_SHORT).show();
     });

--- a/app/src/main/java/app/organicmaps/bitride/mesh/RideMeshCodec.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/RideMeshCodec.kt
@@ -42,6 +42,10 @@ object RideMeshCodec {
       append("ps=${x.positive};")
       append("ng=${x.negative};")
       append("ac=${x.askCancel}")
+      if (x.pickupName.isNotEmpty())
+        append(";pn=${sanitize(x.pickupName)}")
+      if (x.destinationName.isNotEmpty())
+        append(";dn=${sanitize(x.destinationName)}")
       if (x.payment.isNotEmpty())
         append(";pm=${x.payment}")
       if (x.note.isNotEmpty())
@@ -84,7 +88,9 @@ object RideMeshCodec {
     val ac = map["ac"]?.toIntOrNull() ?: 0
     val pm = map["pm"] ?: ""
     val nt = map["nt"] ?: ""
-    return RideRequest('C', h, v!!, p, d, pr, t, tr, ud, ps, ng, ac, pm, nt)
+    val pn = map["pn"] ?: ""
+    val dn = map["dn"] ?: ""
+    return RideRequest('C', h, v!!, p, d, pr, t, tr, ud, ps, ng, ac, pm, nt, pn, dn)
   }
 
   fun decodeDriverReply(raw: String): DriverReply? {

--- a/app/src/main/java/app/organicmaps/bitride/mesh/RideMessageModels.kt
+++ b/app/src/main/java/app/organicmaps/bitride/mesh/RideMessageModels.kt
@@ -23,7 +23,9 @@ data class RideRequest(
   val negative: Int,
   val askCancel: Int,
   val payment: String = "",
-  val note: String = ""
+  val note: String = "",
+  val pickupName: String = "",
+  val destinationName: String = ""
 )
 
 data class DriverReply(

--- a/app/src/main/java/com/undefault/bitride/driverlounge/DriverLoungeScreen.kt
+++ b/app/src/main/java/com/undefault/bitride/driverlounge/DriverLoungeScreen.kt
@@ -1,19 +1,29 @@
 package com.undefault.bitride.driverlounge
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import app.organicmaps.bitride.mesh.VehicleType
 
 /**
- * Layar lounge untuk driver dengan judul sederhana dan konten kosong.
+ * Layar lounge untuk driver yang menampilkan permintaan tumpangan dari channel #bitride.
  */
 @Composable
-fun DriverLoungeScreen() {
+fun DriverLoungeScreen(vm: DriverLoungeViewModel = viewModel()) {
+    val requests by vm.requests.collectAsState()
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -21,10 +31,29 @@ fun DriverLoungeScreen() {
             )
         }
     ) { innerPadding ->
-        Box(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-        )
+        ) {
+            items(requests) { req ->
+                Card(
+                    modifier = Modifier
+                        .padding(16.dp)
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text("customer")
+                        Text("Pickup: ${req.pickupName} (${req.pickup.lat}, ${req.pickup.lon})")
+                        Text("Destination: ${req.destinationName} (${req.destination.lat}, ${req.destination.lon})")
+                        Text("Kendaraan: ${if (req.vehicle == VehicleType.CAR) "Car" else "Motorcycle"}")
+                        Text("Harga: Rp${req.priceRp}")
+                        Text("Pembayaran: ${req.payment}")
+                        Text("Toll: ${if (req.toll) "Ya" else "Tidak"}")
+                        if (req.note.isNotEmpty())
+                            Text("Catatan: ${req.note}")
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/undefault/bitride/driverlounge/DriverLoungeViewModel.kt
+++ b/app/src/main/java/com/undefault/bitride/driverlounge/DriverLoungeViewModel.kt
@@ -1,0 +1,62 @@
+package com.undefault.bitride.driverlounge
+
+import android.app.Application
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import androidx.lifecycle.AndroidViewModel
+import app.organicmaps.bitride.mesh.DriverReply
+import app.organicmaps.bitride.mesh.MeshService
+import app.organicmaps.bitride.mesh.RideConfirm
+import app.organicmaps.bitride.mesh.RideMeshListener
+import app.organicmaps.bitride.mesh.RideRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class DriverLoungeViewModel(app: Application) : AndroidViewModel(app), RideMeshListener {
+    private val _requests = MutableStateFlow<List<RideRequest>>(emptyList())
+    val requests = _requests.asStateFlow()
+
+    private var meshService: MeshService? = null
+    private var bound = false
+
+    private val conn = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            val binder = service as MeshService.MeshBinder
+            meshService = binder.service
+            meshService?.setListener(this@DriverLoungeViewModel)
+            meshService?.startMesh("#bitride")
+            bound = true
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            bound = false
+            meshService = null
+        }
+    }
+
+    init {
+        val context = getApplication<Application>()
+        MeshService.start(context)
+        context.bindService(Intent(context, MeshService::class.java), conn, Context.BIND_AUTO_CREATE)
+    }
+
+    override fun onCleared() {
+        if (bound) {
+            meshService?.setListener(null)
+            getApplication<Application>().unbindService(conn)
+        }
+        super.onCleared()
+    }
+
+    override fun onRideRequestFromCustomer(req: RideRequest, senderPeerId: String) {
+        _requests.value = _requests.value + req
+    }
+    override fun onDriverReply(resp: DriverReply, senderPeerId: String) {}
+    override fun onConfirm(confirm: RideConfirm, senderPeerId: String) {}
+    override fun onChannelMessage(text: String, senderPeerId: String) {}
+    override fun onPeerListUpdated(peers: List<String>) {}
+    override fun onHandshakeComplete(peerId: String) {}
+}

--- a/app/src/test/java/app/organicmaps/bitride/mesh/RideMeshCodecTest.kt
+++ b/app/src/test/java/app/organicmaps/bitride/mesh/RideMeshCodecTest.kt
@@ -23,7 +23,11 @@ class RideMeshCodecTest {
       uniqueDrivers = 7,
       positive = 9,
       negative = 0,
-      askCancel = 1
+      askCancel = 1,
+      payment = "Cash",
+      note = "note",
+      pickupName = "Monas",
+      destinationName = "Sunda"
     )
 
     val s = RideMeshCodec.encodeRequest(req)
@@ -35,6 +39,8 @@ class RideMeshCodecTest {
     assertEquals(req.hashHex, p.hashHex)
     assertEquals(req.vehicle, p.vehicle)
     assertEquals(req.priceRp, p.priceRp)
+    assertEquals(req.pickupName, p.pickupName)
+    assertEquals(req.destinationName, p.destinationName)
   }
 
   @Test


### PR DESCRIPTION
## Ringkasan
- perluas model dan codec pesan untuk menyertakan nama lokasi penjemputan dan tujuan
- kirim detail lokasi, harga, serta preferensi pembayaran saat pelanggan menekan *Bit a Ride*
- tampilkan notifikasi permintaan ride di Driver Lounge lewat ViewModel baru

## Pengujian
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` *(gagal: Plugin [id: 'org.jetbrains.kotlin.plugin.compose'] tidak ditemukan)*

------
https://chatgpt.com/codex/tasks/task_e_68a0933edab083299a069a719ff55910