### PR TITLE
Specify compose plugin version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ buildscript {
 plugins {
   id 'com.android.application'
   id 'org.jetbrains.kotlin.android'
-  id 'org.jetbrains.kotlin.plugin.compose'
+  id 'org.jetbrains.kotlin.plugin.compose' version '1.9.21'
 }
 
 if (googleFirebaseServicesEnabled) {


### PR DESCRIPTION
## Summary
- add explicit version for Kotlin compose plugin

## Testing
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 clean assembleDebug` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c18913d483298e6c491861a9058c