### PR TITLE
Pisahkan dependensi Google Play per flavor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -307,11 +307,18 @@ dependencies {
   implementation 'net.jcip:jcip-annotations:1.0'
   implementation project(':bitchatcore')
   implementation 'androidx.datastore:datastore-preferences:1.1.1'
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.8.1'
+  googleImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.8.1'
+  webImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.8.1'
+  huaweiImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.8.1'
+  fdroidImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
 
   // ML Kit dependencies for KTP scanning and OCR
-  implementation 'com.google.android.gms:play-services-mlkit-document-scanner:16.0.0-beta1'
-  implementation 'com.google.mlkit:text-recognition:16.0.1'
+  googleImplementation 'com.google.android.gms:play-services-mlkit-document-scanner:16.0.0-beta1'
+  webImplementation 'com.google.android.gms:play-services-mlkit-document-scanner:16.0.0-beta1'
+  huaweiImplementation 'com.google.android.gms:play-services-mlkit-document-scanner:16.0.0-beta1'
+  googleImplementation 'com.google.mlkit:text-recognition:16.0.1'
+  webImplementation 'com.google.mlkit:text-recognition:16.0.1'
+  huaweiImplementation 'com.google.mlkit:text-recognition:16.0.1'
   implementation 'io.coil-kt:coil-compose:2.7.0'
 
   // Jetpack Compose


### PR DESCRIPTION
## Ringkasan
- Pindahkan dependensi berbasis Google Play Services ke blok `googleImplementation`, `webImplementation`, dan `huaweiImplementation`.
- Tambahkan `fdroidImplementation` sebagai pengganti coroutine agar build F-Droid tidak menarik artefak `com.google.android.gms`.

## Pengujian
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME :app:assembleFdroidDebug` (gagal: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a0c8396ea88329ba0119e9644423c0