### PR TITLE
Simpan profil driver dan customer di struktur roles Firestore

### DIFF
--- a/app/src/google/java/com/undefault/bitride/auth/RegisterViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/auth/RegisterViewModel.kt
@@ -3,6 +3,8 @@ package com.undefault.bitride.auth
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.firestore.FirebaseFirestore
+import com.undefault.bitride.data.model.CustomerProfile
+import com.undefault.bitride.data.model.DriverProfile
 import com.undefault.bitride.data.repository.UserRepository
 import kotlinx.coroutines.launch
 
@@ -17,24 +19,26 @@ class RegisterViewModel : ViewModel() {
     fun onRegistrationSubmit(hashedNik: String, userName: String, userType: String) {
         viewModelScope.launch {
             if (userType.equals("D", ignoreCase = true)) {
-                val roleExists = userRepository.doesRoleExist(hashedNik, "DRIVER")
+                val roleExists = userRepository.doesRoleExist(hashedNik, "driver")
                 if (roleExists) {
                     println("Error: Akun Driver dengan NIK ini sudah terdaftar!")
                     return@launch
                 }
-                val success = userRepository.createDriverProfile(hashedNik)
+                val profile = DriverProfile(name = userName)
+                val success = userRepository.createDriverProfile(hashedNik, profile)
                 if (success) {
                     println("Pendaftaran profil Driver berhasil untuk: $hashedNik")
                 } else {
                     println("Error: Pendaftaran profil Driver gagal!")
                 }
             } else if (userType.equals("C", ignoreCase = true)) {
-                val roleExists = userRepository.doesRoleExist(hashedNik, "CUSTOMER")
+                val roleExists = userRepository.doesRoleExist(hashedNik, "customer")
                 if (roleExists) {
                     println("Error: Akun Customer dengan NIK ini sudah terdaftar!")
                     return@launch
                 }
-                val success = userRepository.createCustomerProfile(hashedNik)
+                val profile = CustomerProfile(name = userName)
+                val success = userRepository.createCustomerProfile(hashedNik, profile)
                 if (success) {
                     println("Pendaftaran profil Customer berhasil untuk: $hashedNik")
                 } else {

--- a/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.firestore.FirebaseFirestore
+import com.undefault.bitride.data.model.CustomerProfile
 import com.undefault.bitride.data.repository.UserPreferencesRepository
 import com.undefault.bitride.data.repository.UserRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -91,13 +92,17 @@ class CustomerRegistrationViewModel(application: Application) : AndroidViewModel
                 return@launch
             }
 
-            val roleExists = userRepository.doesRoleExist(hashedNik, "CUSTOMER")
+            val roleExists = userRepository.doesRoleExist(hashedNik, "customer")
             if (roleExists) {
                 _uiState.update { it.copy(isLoading = false, validationError = "Akun Customer dengan NIK ini sudah terdaftar.") }
                 return@launch
             }
 
-            val success = userRepository.createCustomerProfile(hashedNik)
+            val profile = CustomerProfile(
+                name = _uiState.value.name,
+                numberOfDifferentDrivers = 0L
+            )
+            val success = userRepository.createCustomerProfile(hashedNik, profile)
             if (success) {
                 Log.d("CustomerRegistrationVM", "Pendaftaran profil Customer berhasil untuk: $hashedNik")
                 userPreferencesRepository.saveLoggedInUser(hashedNik, "CUSTOMER")

--- a/app/src/google/java/com/undefault/bitride/data/model/CustomerProfile.kt
+++ b/app/src/google/java/com/undefault/bitride/data/model/CustomerProfile.kt
@@ -1,0 +1,9 @@
+package com.undefault.bitride.data.model
+
+/**
+ * Profil customer yang disimpan di Firestore di bawah path `roles.customer`.
+ */
+data class CustomerProfile(
+    val name: String = "",
+    val numberOfDifferentDrivers: Long = 0L
+)

--- a/app/src/google/java/com/undefault/bitride/data/model/DriverProfile.kt
+++ b/app/src/google/java/com/undefault/bitride/data/model/DriverProfile.kt
@@ -1,0 +1,11 @@
+package com.undefault.bitride.data.model
+
+/**
+ * Profil driver yang disimpan di Firestore di bawah path `roles.driver`.
+ */
+data class DriverProfile(
+    val name: String = "",
+    val bankName: String = "",
+    val bankAccountNumber: String = "",
+    val numberOfDifferentCustomers: Long = 0L
+)

--- a/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.firestore.FirebaseFirestore
+import com.undefault.bitride.data.model.DriverProfile
 import com.undefault.bitride.data.repository.UserPreferencesRepository
 import com.undefault.bitride.data.repository.UserRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -101,13 +102,19 @@ class DriverRegistrationViewModel(application: Application) : AndroidViewModel(a
                 return@launch
             }
 
-            val roleExists = userRepository.doesRoleExist(hashedNik, "DRIVER")
+            val roleExists = userRepository.doesRoleExist(hashedNik, "driver")
             if (roleExists) {
                 _uiState.update { it.copy(isLoading = false, validationError = "Akun Driver dengan NIK ini sudah terdaftar.") }
                 return@launch
             }
 
-            val success = userRepository.createDriverProfile(hashedNik)
+            val profile = DriverProfile(
+                name = _uiState.value.name,
+                bankName = _uiState.value.bankName,
+                bankAccountNumber = _uiState.value.bankAccountNumber,
+                numberOfDifferentCustomers = 0L
+            )
+            val success = userRepository.createDriverProfile(hashedNik, profile)
             if (success) {
                 Log.d("DriverRegistrationVM", "Pendaftaran profil Driver berhasil untuk: $hashedNik")
                 userPreferencesRepository.saveLoggedInUser(hashedNik, "DRIVER")


### PR DESCRIPTION
## Ringkasan
- Tambah model `DriverProfile` dan `CustomerProfile` dengan nama variabel yang benar.
- Simpan profil di `users/<nikHash>` dengan struktur `roles.driver` dan `roles.customer` pada `UserRepository`.
- Perbarui view model registrasi agar membuat dan mengirim objek profil ke repository.

## Pengujian
- `./gradlew test` (gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)


------
https://chatgpt.com/codex/tasks/task_e_68a337578b5483298f42216772f06909