### PR TITLE
Sesuaikan navigasi ChooseRole dengan rute tujuan

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -44,7 +44,7 @@ fun ChooseRoleScreen(
             if (uiState.canLoginAsCustomer) {
                 Button(onClick = {
                     MeshManager.start(context)
-                    viewModel.checkDataAndGetNextRoute(navigateToNextScreen)
+                    viewModel.checkDataAndGetNextRoute(Routes.MAIN, navigateToNextScreen)
                 }) {
                     Text("Masuk sebagai Customer")
                 }
@@ -53,7 +53,7 @@ fun ChooseRoleScreen(
             if (uiState.canLoginAsDriver) {
                 Button(onClick = {
                     MeshManager.start(context)
-                    navController.navigate(Routes.DRIVER_LOUNGE)
+                    viewModel.checkDataAndGetNextRoute(Routes.DRIVER_LOUNGE, navigateToNextScreen)
                 }) {
                     Text("Masuk sebagai Driver")
                 }

--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
@@ -56,7 +56,7 @@ class ChooseRoleViewModel @Inject constructor(
         }
     }
 
-    fun checkDataAndGetNextRoute(onResult: (String) -> Unit) {
+    fun checkDataAndGetNextRoute(targetRoute: String, onResult: (String) -> Unit) {
         viewModelScope.launch {
             val mapFileStoredName = dataStoreRepository.activeMapFileNameFlow.firstOrNull()
             val dbFileStoredName = dataStoreRepository.activePoiDbNameFlow.firstOrNull()
@@ -69,7 +69,7 @@ class ChooseRoleViewModel @Inject constructor(
                     dbFile?.exists() == true &&
                     brouterDir.exists() && (brouterDir.listFiles()?.any { it.name.endsWith(".rd5") } == true)
 
-            val destination = if (allDataExists) Routes.DRIVER_LOUNGE else Routes.IMPORT
+            val destination = if (allDataExists) targetRoute else Routes.IMPORT
             onResult(destination)
         }
     }

--- a/app/src/google/java/com/undefault/bitride/navigation/Routes.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/Routes.kt
@@ -10,6 +10,7 @@ object Routes {
     const val CUSTOMER_REGISTRATION_FORM = "customer_registration_form"
     const val DRIVER_REGISTRATION_FORM = "driver_registration_form"
     const val DRIVER_LOUNGE = "driver_lounge"
+    const val MAIN = "main"
     const val IMPORT = "import"
 
     /**

--- a/bitride/app/src/main/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/bitride/app/src/main/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -39,15 +39,14 @@ fun ChooseRoleScreen(
             verticalArrangement = Arrangement.Center
         ) {
             if (uiState.canLoginAsCustomer) {
-                Button(onClick = { viewModel.checkDataAndGetNextRoute(navigateToNextScreen) }) {
+                Button(onClick = { viewModel.checkDataAndGetNextRoute(Routes.MAIN, navigateToNextScreen) }) {
                     Text("Masuk sebagai Customer")
                 }
                 Spacer(modifier = Modifier.height(16.dp))
             }
             if (uiState.canLoginAsDriver) {
                 Button(onClick = {
-                    // TODO: Logika untuk driver bisa sama atau berbeda
-                    viewModel.checkDataAndGetNextRoute(navigateToNextScreen)
+                    viewModel.checkDataAndGetNextRoute(Routes.DRIVER_LOUNGE, navigateToNextScreen)
                 }) {
                     Text("Masuk sebagai Driver")
                 }

--- a/bitride/app/src/main/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
+++ b/bitride/app/src/main/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
@@ -54,7 +54,7 @@ class ChooseRoleViewModel @Inject constructor(
         }
     }
 
-    fun checkDataAndGetNextRoute(onResult: (String) -> Unit) {
+    fun checkDataAndGetNextRoute(targetRoute: String, onResult: (String) -> Unit) {
         viewModelScope.launch {
             val mapFileStoredName = dataStoreRepository.activeMapFileNameFlow.firstOrNull()
             val dbFileStoredName = dataStoreRepository.activePoiDbNameFlow.firstOrNull()
@@ -67,7 +67,7 @@ class ChooseRoleViewModel @Inject constructor(
                     dbFile?.exists() == true &&
                     brouterDir.exists() && (brouterDir.listFiles()?.any { it.name.endsWith(".rd5") } == true)
 
-            val destination = if (allDataExists) Routes.DRIVER_LOUNGE else Routes.IMPORT
+            val destination = if (allDataExists) targetRoute else Routes.IMPORT
             onResult(destination)
         }
     }


### PR DESCRIPTION
## Ringkasan
- Tambah parameter tujuan pada `checkDataAndGetNextRoute` dan kembalikan `Routes.IMPORT` bila data belum lengkap
- Panggil pengecekan data pada tombol masuk customer dan driver dengan rute berbeda
- Tambah konstanta `MAIN` pada `Routes`

## Pengujian
- `./gradlew test -Dorg.gradle.java.home=$JAVA_HOME` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68a342d68b408329816b9b0f46e4b1f9