### PR TITLE
Persist and merge user roles list during registration

### DIFF
--- a/app/src/google/java/com/undefault/bitride/data/repository/DataStoreRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/DataStoreRepository.kt
@@ -69,13 +69,10 @@ class DataStoreRepository @Inject constructor(
         }
     }
 
-    suspend fun saveLoggedInUser(nikHash: String, role: String) {
+    suspend fun saveLoggedInUser(nikHash: String, roles: List<String>) {
         dataStore.edit { prefs ->
             prefs[KEY_NIK_HASH] = nikHash
-            val roles = prefs[KEY_ROLES]?.split(",")?.toMutableSet() ?: mutableSetOf()
-            if (roles.add(role)) {
-                prefs[KEY_ROLES] = roles.joinToString(",")
-            }
+            prefs[KEY_ROLES] = roles.toSet().joinToString(",")
         }
     }
 

--- a/app/src/google/java/com/undefault/bitride/data/repository/UserPreferencesRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/UserPreferencesRepository.kt
@@ -12,7 +12,9 @@ class UserPreferencesRepository @Inject constructor(
     constructor(context: Context) : this(DataStoreRepository(context))
 
     suspend fun saveLoggedInUser(nikHash: String, role: String) {
-        dataStoreRepository.saveLoggedInUser(nikHash, role)
+        val roles = dataStoreRepository.rolesFlow.firstOrNull()?.toMutableSet() ?: mutableSetOf()
+        roles.add(role)
+        dataStoreRepository.saveLoggedInUser(nikHash, roles.toList())
     }
 
     suspend fun getLoggedInUser(): LoggedInData? {


### PR DESCRIPTION
## Summary
- store complete role list when saving logged-in user
- merge new role into existing roles instead of overwriting

## Testing
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a34cf614488329a248776bcf381c42