### PR TITLE
Gunakan statistik profil saat membuat RideRequest

### DIFF
--- a/app/src/google/java/app/organicmaps/bitride/RideRequestViewModel.kt
+++ b/app/src/google/java/app/organicmaps/bitride/RideRequestViewModel.kt
@@ -1,0 +1,17 @@
+package app.organicmaps.bitride
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
+import com.undefault.bitride.data.repository.UserProfileRepository
+import com.undefault.bitride.data.repository.UserProfileStats
+
+@HiltViewModel
+class RideRequestViewModel @Inject constructor(
+    private val userProfileRepository: UserProfileRepository
+) : ViewModel() {
+    fun getStatsBlocking(): UserProfileStats = runBlocking {
+        userProfileRepository.getActiveUserStats()
+    }
+}

--- a/app/src/google/java/com/undefault/bitride/data/repository/FirestoreUserProfileRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/FirestoreUserProfileRepository.kt
@@ -1,0 +1,39 @@
+package com.undefault.bitride.data.repository
+
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Implementasi [UserProfileRepository] yang mengambil data dari Firestore
+ * berdasarkan nikHash dan peran pengguna aktif.
+ */
+@Singleton
+class FirestoreUserProfileRepository @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val userPreferencesRepository: UserPreferencesRepository
+) : UserProfileRepository {
+
+    override suspend fun getActiveUserStats(): UserProfileStats {
+        val loggedIn = userPreferencesRepository.getLoggedInUser() ?: return UserProfileStats()
+        val role = loggedIn.roles.firstOrNull() ?: return UserProfileStats()
+        val snapshot = firestore.collection("users").document(loggedIn.nikHash).get().await()
+        val base = "roles.$role"
+
+        fun getInt(field: String): Int = (snapshot.get("$base.$field") as? Long)?.toInt() ?: 0
+
+        val unique = if (role == "customer")
+            getInt("uniqueDrivers")
+        else
+            getInt("uniqueCustomers")
+
+        return UserProfileStats(
+            totalRides = getInt("totalRides"),
+            uniquePartners = unique,
+            positive = getInt("positive"),
+            negative = getInt("negative"),
+            askCancel = getInt("askCancel")
+        )
+    }
+}

--- a/app/src/google/java/com/undefault/bitride/di/RepositoryModule.kt
+++ b/app/src/google/java/com/undefault/bitride/di/RepositoryModule.kt
@@ -2,6 +2,9 @@ package com.undefault.bitride.di
 
 import android.app.Application
 import com.undefault.bitride.data.repository.UserPreferencesRepository
+import com.undefault.bitride.data.repository.UserProfileRepository
+import com.undefault.bitride.data.repository.FirestoreUserProfileRepository
+import com.google.firebase.firestore.FirebaseFirestore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,4 +20,12 @@ object RepositoryModule {
     fun provideUserPreferencesRepository(
         app: Application
     ): UserPreferencesRepository = UserPreferencesRepository(app)
+
+    @Provides
+    @Singleton
+    fun provideUserProfileRepository(
+        firestore: FirebaseFirestore,
+        userPreferencesRepository: UserPreferencesRepository
+    ): UserProfileRepository =
+        FirestoreUserProfileRepository(firestore, userPreferencesRepository)
 }

--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -55,6 +55,7 @@ import androidx.fragment.app.FragmentFactory;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
+import dagger.hilt.android.AndroidEntryPoint;
 import app.organicmaps.api.Const;
 import app.organicmaps.base.BaseMwmFragmentActivity;
 import app.organicmaps.base.OnBackPressListener;
@@ -82,7 +83,9 @@ import app.organicmaps.routing.RoutingPlanFragment;
 import app.organicmaps.routing.RoutingPlanInplaceController;
 import app.organicmaps.bitride.mesh.MeshService;
 import app.organicmaps.bitride.mesh.RideMeshCodec;
+import app.organicmaps.bitride.RideRequestViewModel;
 import app.organicmaps.bitride.mesh.RideRequest;
+import com.undefault.bitride.data.repository.UserProfileStats;
 import app.organicmaps.bitride.mesh.GeoPoint;
 import app.organicmaps.bitride.mesh.VehicleType;
 import app.organicmaps.sdk.ChoosePositionMode;
@@ -140,6 +143,7 @@ import java.util.ArrayList;
 import java.util.Objects;
 import app.organicmaps.sdk.routing.RoutingInfo;
 
+@AndroidEntryPoint
 public class MwmActivity extends BaseMwmFragmentActivity
     implements PlacePageActivationListener, View.OnTouchListener, MapRenderingListener, RoutingController.Container,
                LocationListener, SensorListener, LocationState.ModeChangeListener,
@@ -278,6 +282,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private View mRoutingProgressOverlay;
   @Nullable private Router mSelectedRouter;
   private MeshService mMeshService;
+  private RideRequestViewModel mRideRequestViewModel;
   private boolean mMeshBound = false;
   private final ServiceConnection mMeshConn = new ServiceConnection() {
     @Override
@@ -621,6 +626,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     mPlacePageViewModel = new ViewModelProvider(this).get(PlacePageViewModel.class);
     mMapButtonsViewModel = new ViewModelProvider(this).get(MapButtonsViewModel.class);
+    mRideRequestViewModel = new ViewModelProvider(this).get(RideRequestViewModel.class);
     // We don't need to manually handle removing the observers it follows the activity lifecycle
     mMapButtonsViewModel.getBottomButtonsHeight().observe(this, this::onMapBottomButtonsHeightChange);
     mMapButtonsViewModel.getLayoutMode().observe(this, this::initNavigationButtons);
@@ -747,8 +753,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
       String pickupName = startPoint.getName();
       String destinationName = endPoint.getName();
       String note = mNoteEditText.getText() == null ? "" : mNoteEditText.getText().toString();
+      UserProfileStats stats = mRideRequestViewModel.getStatsBlocking();
       RideRequest req = new RideRequest('C', hash, vehicle, pickup, destination, price,
-                                        mTollSwitch.isChecked(), 0, 0, 0, 0, 0,
+                                        mTollSwitch.isChecked(), stats.getTotalRides(),
+                                        stats.getUniquePartners(), stats.getPositive(),
+                                        stats.getNegative(), stats.getAskCancel(),
                                         mPaymentType, note, pickupName, destinationName);
       mMeshService.sendChannelMessage(RideMeshCodec.encodeRequest(req));
       Toast.makeText(this, "Permintaan tumpangan dikirim", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/undefault/bitride/data/repository/UserProfileRepository.kt
+++ b/app/src/main/java/com/undefault/bitride/data/repository/UserProfileRepository.kt
@@ -1,0 +1,16 @@
+package com.undefault.bitride.data.repository
+
+/**
+ * Menyediakan statistik profil pengguna untuk permintaan tumpangan.
+ */
+data class UserProfileStats(
+    val totalRides: Int = 0,
+    val uniquePartners: Int = 0,
+    val positive: Int = 0,
+    val negative: Int = 0,
+    val askCancel: Int = 0
+)
+
+interface UserProfileRepository {
+    suspend fun getActiveUserStats(): UserProfileStats
+}


### PR DESCRIPTION
## Ringkasan
- Tambah `UserProfileRepository` untuk membaca statistik pengguna dari Firestore/DataStore.
- Sediakan `FirestoreUserProfileRepository` dan `RideRequestViewModel` agar `MwmActivity` dapat mengambil statistik sebelum mengirim `RideRequest`.
- Ganti nilai placeholder pada `RideRequest` dengan data profil yang sesungguhnya dan tetap kirim ke channel `#bitride`.

## Pengujian
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 test` (gagal: Process 'command 'bash'' finished dengan exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68a35a13ea1c8329b0510ebfec10009b