### PR TITLE
Mulai mesh sebelum masuk driver lounge

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -25,6 +25,9 @@ fun ChooseRoleScreen(
     val context = LocalContext.current
 
     val navigateToNextScreen = { destination: String ->
+        if (destination == Routes.DRIVER_LOUNGE) {
+            MeshManager.start(context)
+        }
         navController.navigate(destination) {
             // Bersihkan semua layar sebelumnya sampai ke awal
             popUpTo(navController.graph.startDestinationId) { inclusive = true }
@@ -52,7 +55,6 @@ fun ChooseRoleScreen(
             }
             if (uiState.canLoginAsDriver) {
                 Button(onClick = {
-                    MeshManager.start(context)
                     viewModel.checkDataAndGetNextRoute(Routes.DRIVER_LOUNGE, navigateToNextScreen)
                 }) {
                     Text("Masuk sebagai Driver")


### PR DESCRIPTION
## Ringkasan
- Panggil `MeshManager.start` sesaat sebelum navigasi ke `DriverLoungeScreen` setelah pengecekan data.
- Pastikan login driver tidak memulai mesh lebih awal.

## Pengujian
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 test` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a35ca8d1348329bd3671c00a78372e