### PR TITLE
Integrasi peran pengguna dan penyimpanan profil

### DIFF
--- a/app/src/google/java/com/undefault/bitride/data/repository/UserPreferencesRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/UserPreferencesRepository.kt
@@ -11,17 +11,30 @@ class UserPreferencesRepository @Inject constructor(
 ) {
     constructor(context: Context) : this(DataStoreRepository(context))
 
+    private val rolesCache = mutableSetOf<String>()
+
     suspend fun saveLoggedInUser(nikHash: String, role: String) {
+        if (rolesCache.isEmpty()) {
+            rolesCache.addAll(dataStoreRepository.rolesFlow.firstOrNull() ?: emptyList())
+        }
+        rolesCache.add(role)
         dataStoreRepository.saveLoggedInUser(nikHash, role)
     }
 
     suspend fun getLoggedInUser(): LoggedInData? {
         val nik = dataStoreRepository.nikHashFlow.firstOrNull()
-        val roles = dataStoreRepository.rolesFlow.firstOrNull() ?: emptyList()
+        val roles = if (rolesCache.isEmpty()) {
+            val stored = dataStoreRepository.rolesFlow.firstOrNull() ?: emptyList()
+            rolesCache.addAll(stored)
+            stored
+        } else {
+            rolesCache.toList()
+        }
         return if (nik != null) LoggedInData(nik, roles) else null
     }
 
     suspend fun clearLoggedInUser() {
         dataStoreRepository.clearLoggedInUser()
+        rolesCache.clear()
     }
 }


### PR DESCRIPTION
## Ringkasan
- Tambah pemanggilan UserRepository pada proses registrasi driver dan customer untuk membuat profil di Firestore serta menyimpan peran secara lokal.
- Pertahankan hashing NIK dengan SHA-256 dan gunakan penyimpanan DataStore untuk info personal dan bank.
- Simpan daftar peran pada UserPreferencesRepository sehingga peran baru dapat ditambahkan tanpa menimpa peran lama.

## Pengujian
- `./gradlew test -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2` (gagal: Process 'command 'bash'' finished with non-zero exit value 127 karena skrip tools/unix/version.sh tidak ditemukan)

------
https://chatgpt.com/codex/tasks/task_e_68a35fac2b188329a158aa0b14c027a0