### PR TITLE
Allow Hilt to override activity lifecycle

### DIFF
--- a/app/src/main/java/app/organicmaps/base/BaseMwmFragmentActivity.java
+++ b/app/src/main/java/app/organicmaps/base/BaseMwmFragmentActivity.java
@@ -54,12 +54,12 @@ public abstract class BaseMwmFragmentActivity extends AppCompatActivity
   /**
    * Shows splash screen and initializes the core in case when it was not initialized.
    *
-   * Do not override this method!
-   * Use {@link #onSafeCreate(Bundle savedInstanceState)}
+   * This method is kept non-final so Hilt can inject {@code SavedStateHandle}.
+   * Avoid overriding it and use {@link #onSafeCreate(Bundle savedInstanceState)} instead.
    */
   @CallSuper
   @Override
-  protected final void onCreate(@Nullable Bundle savedInstanceState)
+  protected void onCreate(@Nullable Bundle savedInstanceState)
   {
     super.onCreate(savedInstanceState);
     mThemeName = Config.getCurrentUiTheme(getApplicationContext());
@@ -94,9 +94,13 @@ public abstract class BaseMwmFragmentActivity extends AppCompatActivity
     mSafeCreated = true;
   }
 
+  /**
+   * Non-final to allow Hilt to clean up {@code SavedStateHandle}.
+   * Override {@link #onSafeDestroy()} instead for custom logic.
+   */
   @CallSuper
   @Override
-  protected final void onDestroy()
+  protected void onDestroy()
   {
     super.onDestroy();
 


### PR DESCRIPTION
## Ringkasan
- Hilangkan modifier final pada `onCreate` dan `onDestroy` di `BaseMwmFragmentActivity` agar Hilt dapat menyisipkan `SavedStateHandle`.
- Tambahkan dokumentasi yang menjelaskan bahwa metode tersebut tetap tidak dianjurkan untuk dioverride secara langsung.

## Pengujian
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/17.0.2 :app:kaptGoogleDebugKotlin` *(gagal: Build file '/workspace/organic-maps-ride/build.gradle' line: 14 - Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a3368160508329ad387534452ed133