### PR TITLE
Gunakan MapManager untuk cek peta dan hapus rute impor

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
@@ -6,13 +6,13 @@ import androidx.lifecycle.viewModelScope
 import com.undefault.bitride.data.repository.DataStoreRepository
 import com.undefault.bitride.data.repository.UserPreferencesRepository
 import com.undefault.bitride.navigation.Routes
+import app.organicmaps.downloader.DownloaderActivity
+import app.organicmaps.sdk.downloader.MapManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
-import java.io.File
 import javax.inject.Inject
 
 data class ChooseRoleUiState(
@@ -58,19 +58,16 @@ class ChooseRoleViewModel @Inject constructor(
 
     fun checkDataAndGetNextRoute(destination: String, onResult: (String) -> Unit) {
         viewModelScope.launch {
-            val mapFileStoredName = dataStoreRepository.activeMapFileNameFlow.firstOrNull()
-            val dbFileStoredName = dataStoreRepository.activePoiDbNameFlow.firstOrNull()
+            val hasMaps = MapManager.nativeGetDownloadedCount() > 0
 
-            val mapFile = if (mapFileStoredName.isNullOrBlank()) null else File(context.filesDir, mapFileStoredName)
-            val dbFile = if (dbFileStoredName.isNullOrBlank()) null else File(context.filesDir, dbFileStoredName)
-            val brouterDir = File(context.filesDir, "brouter/segments4")
-
-            val allDataExists = mapFile?.exists() == true &&
-                dbFile?.exists() == true &&
-                brouterDir.exists() && (brouterDir.listFiles()?.any { it.name.endsWith(".rd5") } == true)
-
-            val nextRoute = if (allDataExists) destination else Routes.IMPORT
-            onResult(nextRoute)
+            if (hasMaps) {
+                // Simpan nama berkas ke DataStore jika belum ada.
+                dataStoreRepository.setActiveMapFileName("default.mwm")
+                dataStoreRepository.setActivePoiDbName("default.poi.db")
+                onResult(destination)
+            } else {
+                context.startActivity(android.content.Intent(context, DownloaderActivity::class.java))
+            }
         }
     }
 }

--- a/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
@@ -1,13 +1,7 @@
 package com.undefault.bitride.navigation
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -111,15 +105,6 @@ fun AppNavigation() {
                 },
                 onNavigateToScanKtp = { navController.navigate(Routes.idCardScanWithArgs("driver", true)) }
             )
-        }
-        placeholderScreen(Routes.IMPORT, "Impor Data")
-    }
-}
-
-private fun NavGraphBuilder.placeholderScreen(route: String, title: String) {
-    composable(route) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(title)
         }
     }
 }

--- a/app/src/google/java/com/undefault/bitride/navigation/Routes.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/Routes.kt
@@ -11,7 +11,6 @@ object Routes {
     const val DRIVER_REGISTRATION_FORM = "driver_registration_form"
     const val DRIVER_LOUNGE = "driver_lounge"
     const val MAIN = "main"
-    const val IMPORT = "import"
 
     /**
      * Rute untuk membuka layar pemindaian KTP.


### PR DESCRIPTION
## Ringkasan
- Gunakan `MapManager` untuk memeriksa ketersediaan peta dan membuka `DownloaderActivity` jika belum ada
- Simpan nama berkas peta ke `DataStore` setelah map tersedia
- Hapus rute placeholder `Routes.IMPORT` dari navigasi

## Pengujian
- `./gradlew -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64 test` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a372cbd74c832992fb5cf742a1237a