### PR TITLE
Arahkan customer ke peta lengkap dan hapus route MAIN

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
+import android.app.Activity
+import android.content.Intent
+import app.organicmaps.MwmActivity
 import app.organicmaps.bitride.mesh.MeshManager
 import com.undefault.bitride.navigation.Routes
 
@@ -46,7 +49,16 @@ fun ChooseRoleScreen(
         ) {
             if (uiState.canLoginAsCustomer) {
                 Button(onClick = {
-                    viewModel.checkDataAndGetNextRoute(Routes.MAIN, navigateToNextScreen)
+                    viewModel.checkDataAndGetNextRoute("peta lengkap") { destination ->
+                        if (destination == "peta lengkap") {
+                            context.startActivity(Intent(context, MwmActivity::class.java))
+                            if (context is Activity) {
+                                (context as Activity).finish()
+                            }
+                        } else {
+                            navigateToNextScreen(destination)
+                        }
+                    }
                 }) {
                     Text("Masuk sebagai Customer")
                 }

--- a/app/src/google/java/com/undefault/bitride/navigation/Routes.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/Routes.kt
@@ -10,7 +10,6 @@ object Routes {
     const val CUSTOMER_REGISTRATION_FORM = "customer_registration_form"
     const val DRIVER_REGISTRATION_FORM = "driver_registration_form"
     const val DRIVER_LOUNGE = "driver_lounge"
-    const val MAIN = "main"
 
     /**
      * Rute untuk membuka layar pemindaian KTP.


### PR DESCRIPTION
## Ringkasan
- Luncurkan `MwmActivity` saat data customer lengkap dan akhiri activity Compose.
- Hapus konstanta `Routes.MAIN` beserta seluruh referensinya.

## Pengujian
- `./gradlew test` (gagal karena script `version.sh` tidak ditemukan)


------
https://chatgpt.com/codex/tasks/task_e_68a3787332348329a12c523ef2b04446