### PR TITLE
Refactor user profiles to store stats only

### DIFF
--- a/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
@@ -93,7 +93,8 @@ class CustomerRegistrationViewModel(application: Application) : AndroidViewModel
                 return@launch
             }
 
-            val profile = CustomerProfile(name = _uiState.value.name)
+            // Profil awal hanya berisi statistik dengan nilai 0
+            val profile = CustomerProfile()
 
             val success = userRepository.createCustomerProfile(hashedNik, profile)
             if (success) {

--- a/app/src/google/java/com/undefault/bitride/data/model/CustomerProfile.kt
+++ b/app/src/google/java/com/undefault/bitride/data/model/CustomerProfile.kt
@@ -2,8 +2,13 @@ package com.undefault.bitride.data.model
 
 /**
  * Profil customer yang disimpan di Firestore di bawah path `roles.customer`.
+ * Hanya berisi statistik tanpa data pribadi.
  */
 data class CustomerProfile(
-    val name: String = "",
-    val numberOfDifferentDrivers: Long = 0L
+    val totalRides: Long = 0L,
+    val successfulPayments: Long = 0L,
+    val numberOfDifferentDrivers: Long = 0L,
+    val askingCancel: Long = 0L,
+    val positiveRate: Long = 0L,
+    val negativeRate: Long = 0L
 )

--- a/app/src/google/java/com/undefault/bitride/data/model/DriverProfile.kt
+++ b/app/src/google/java/com/undefault/bitride/data/model/DriverProfile.kt
@@ -2,10 +2,13 @@ package com.undefault.bitride.data.model
 
 /**
  * Profil driver yang disimpan di Firestore di bawah path `roles.driver`.
+ * Hanya berisi statistik tanpa data pribadi.
  */
 data class DriverProfile(
-    val name: String = "",
-    val bankName: String = "",
-    val bankAccountNumber: String = "",
-    val numberOfDifferentCustomers: Long = 0L
+    val totalRides: Long = 0L,
+    val successfulRides: Long = 0L,
+    val numberOfDifferentCustomers: Long = 0L,
+    val askingCancel: Long = 0L,
+    val positiveRate: Long = 0L,
+    val negativeRate: Long = 0L
 )

--- a/app/src/google/java/com/undefault/bitride/data/repository/FirestoreUserProfileRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/FirestoreUserProfileRepository.kt
@@ -23,17 +23,23 @@ class FirestoreUserProfileRepository @Inject constructor(
 
         fun getInt(field: String): Int = (snapshot.get("$base.$field") as? Long)?.toInt() ?: 0
 
-        val unique = if (role == "customer")
-            getInt("uniqueDrivers")
+        val success = if (role == "driver")
+            getInt("successfulRides")
         else
-            getInt("uniqueCustomers")
+            getInt("successfulPayments")
+
+        val unique = if (role == "customer")
+            getInt("numberOfDifferentDrivers")
+        else
+            getInt("numberOfDifferentCustomers")
 
         return UserProfileStats(
             totalRides = getInt("totalRides"),
+            successful = success,
             uniquePartners = unique,
-            positive = getInt("positive"),
-            negative = getInt("negative"),
-            askCancel = getInt("askCancel")
+            positive = getInt("positiveRate"),
+            negative = getInt("negativeRate"),
+            askCancel = getInt("askingCancel")
         )
     }
 }

--- a/app/src/google/java/com/undefault/bitride/data/repository/UserRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/UserRepository.kt
@@ -20,8 +20,8 @@ class UserRepository @Inject constructor(
         false
     }
 
-    suspend fun createDriverProfile(nikHash: String, profile: DriverProfile): Boolean = try {
-        val data = mapOf("roles" to mapOf("driver" to profile))
+    suspend fun createDriverProfile(nikHash: String, stats: DriverProfile): Boolean = try {
+        val data = mapOf("roles" to mapOf("driver" to stats))
         firestore.collection("users").document(nikHash)
             .set(data, SetOptions.merge())
             .await()
@@ -30,8 +30,8 @@ class UserRepository @Inject constructor(
         false
     }
 
-    suspend fun createCustomerProfile(nikHash: String, profile: CustomerProfile): Boolean = try {
-        val data = mapOf("roles" to mapOf("customer" to profile))
+    suspend fun createCustomerProfile(nikHash: String, stats: CustomerProfile): Boolean = try {
+        val data = mapOf("roles" to mapOf("customer" to stats))
         firestore.collection("users").document(nikHash)
             .set(data, SetOptions.merge())
             .await()

--- a/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
@@ -103,11 +103,8 @@ class DriverRegistrationViewModel(application: Application) : AndroidViewModel(a
                 return@launch
             }
 
-            val profile = DriverProfile(
-                name = _uiState.value.name,
-                bankName = _uiState.value.bankName,
-                bankAccountNumber = _uiState.value.bankAccountNumber
-            )
+            // Profil awal hanya berisi statistik dengan nilai 0
+            val profile = DriverProfile()
 
             val success = userRepository.createDriverProfile(hashedNik, profile)
             if (success) {

--- a/app/src/main/java/com/undefault/bitride/data/repository/UserProfileRepository.kt
+++ b/app/src/main/java/com/undefault/bitride/data/repository/UserProfileRepository.kt
@@ -5,6 +5,7 @@ package com.undefault.bitride.data.repository
  */
 data class UserProfileStats(
     val totalRides: Int = 0,
+    val successful: Int = 0,
     val uniquePartners: Int = 0,
     val positive: Int = 0,
     val negative: Int = 0,


### PR DESCRIPTION
## Summary
- Hapus informasi pribadi dari profil driver dan customer
- Simpan statistik dasar rides pada Firestore
- Sesuaikan repository dan view model untuk profil baru

## Testing
- `./gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68a38067b7cc8329b13dc450500ff5c9