### PR TITLE
Pindahkan penyimpanan info lokal sebelum kirim profil ke Firestore

### DIFF
--- a/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
@@ -95,10 +95,11 @@ class CustomerRegistrationViewModel(application: Application) : AndroidViewModel
 
             // Profil awal hanya berisi statistik dengan nilai 0
             val profile = CustomerProfile()
+            dataStoreRepository.savePersonalInfo(_uiState.value.name, nik)
+            dataStoreRepository.saveBankInfo("", "")
 
             val success = userRepository.createCustomerProfile(hashedNik, profile)
             if (success) {
-                dataStoreRepository.savePersonalInfo(_uiState.value.name, nik)
                 userPreferencesRepository.saveLoggedInUser(hashedNik, "customer")
                 Log.d("CustomerRegistrationVM", "Data customer disimpan ke storage lokal dan Firestore.")
                 _uiState.update { it.copy(isLoading = false, registrationSuccess = true) }

--- a/app/src/google/java/com/undefault/bitride/data/repository/UserRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package com.undefault.bitride.data.repository
 
+import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
 import com.undefault.bitride.data.model.CustomerProfile
@@ -22,6 +23,7 @@ class UserRepository @Inject constructor(
 
     suspend fun createDriverProfile(nikHash: String, stats: DriverProfile): Boolean = try {
         val data = mapOf("roles" to mapOf("driver" to stats))
+        Log.d("UserRepository", "createDriverProfile payload: $data")
         firestore.collection("users").document(nikHash)
             .set(data, SetOptions.merge())
             .await()
@@ -32,6 +34,7 @@ class UserRepository @Inject constructor(
 
     suspend fun createCustomerProfile(nikHash: String, stats: CustomerProfile): Boolean = try {
         val data = mapOf("roles" to mapOf("customer" to stats))
+        Log.d("UserRepository", "createCustomerProfile payload: $data")
         firestore.collection("users").document(nikHash)
             .set(data, SetOptions.merge())
             .await()

--- a/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
@@ -105,11 +105,11 @@ class DriverRegistrationViewModel(application: Application) : AndroidViewModel(a
 
             // Profil awal hanya berisi statistik dengan nilai 0
             val profile = DriverProfile()
+            dataStoreRepository.savePersonalInfo(_uiState.value.name, nik)
+            dataStoreRepository.saveBankInfo(_uiState.value.bankName, _uiState.value.bankAccountNumber)
 
             val success = userRepository.createDriverProfile(hashedNik, profile)
             if (success) {
-                dataStoreRepository.savePersonalInfo(_uiState.value.name, nik)
-                dataStoreRepository.saveBankInfo(_uiState.value.bankName, _uiState.value.bankAccountNumber)
                 userPreferencesRepository.saveLoggedInUser(hashedNik, "driver")
                 Log.d("DriverRegistrationVM", "Data driver disimpan ke storage lokal dan Firestore.")
                 _uiState.update { it.copy(isLoading = false, registrationSuccess = true) }


### PR DESCRIPTION
## Ringkasan
- Pindahkan penyimpanan info pribadi dan bank ke DataStore sebelum penulisan profil ke Firestore.
- Tambahkan logging payload Firestore untuk memastikan tidak ada data nama/NIK/bank yang terkirim.

## Pengujian
- `./gradlew test` (gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)


------
https://chatgpt.com/codex/tasks/task_e_68a384742bc48329bd77e0dfe697ea15