### PR TITLE
feat: log personal info absence in Firestore payloads

### DIFF
--- a/app/src/google/java/com/undefault/bitride/data/repository/UserRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/UserRepository.kt
@@ -14,6 +14,15 @@ class UserRepository @Inject constructor(
     private val firestore: FirebaseFirestore
 ) {
 
+    private fun logPayload(action: String, data: Any) {
+        val payloadString = data.toString().lowercase()
+        if (payloadString.contains("name") || payloadString.contains("nik") || payloadString.contains("bank")) {
+            Log.w("UserRepository", "$action payload contains personal info: $payloadString")
+        } else {
+            Log.d("UserRepository", "$action payload: $payloadString")
+        }
+    }
+
     suspend fun doesRoleExist(nikHash: String, role: String): Boolean = try {
         val snapshot = firestore.collection("users").document(nikHash).get().await()
         snapshot.get("roles.$role") != null
@@ -23,7 +32,7 @@ class UserRepository @Inject constructor(
 
     suspend fun createDriverProfile(nikHash: String, stats: DriverProfile): Boolean = try {
         val data = mapOf("roles" to mapOf("driver" to stats))
-        Log.d("UserRepository", "createDriverProfile payload: $data")
+        logPayload("createDriverProfile", data)
         firestore.collection("users").document(nikHash)
             .set(data, SetOptions.merge())
             .await()
@@ -34,7 +43,7 @@ class UserRepository @Inject constructor(
 
     suspend fun createCustomerProfile(nikHash: String, stats: CustomerProfile): Boolean = try {
         val data = mapOf("roles" to mapOf("customer" to stats))
-        Log.d("UserRepository", "createCustomerProfile payload: $data")
+        logPayload("createCustomerProfile", data)
         firestore.collection("users").document(nikHash)
             .set(data, SetOptions.merge())
             .await()


### PR DESCRIPTION
## Summary
- log and verify Firestore payloads contain no name, NIK, or bank fields

## Testing
- `./gradlew :app:test -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a386de34b483298f76d9b6c2f6f6ad