### PR TITLE
Hapus MeshManager.start dari alur registrasi

### DIFF
--- a/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
@@ -1,7 +1,6 @@
 package com.undefault.bitride.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -13,7 +12,6 @@ import com.undefault.bitride.customerregistrationform.CustomerRegistrationFormSc
 import com.undefault.bitride.driverregistrationform.DriverRegistrationFormScreen
 import com.undefault.bitride.idcardscan.IdCardScanScreen
 import com.undefault.bitride.driverlounge.DriverLoungeScreen
-import app.organicmaps.bitride.mesh.MeshManager
 
 /**
  * Menangani navigasi aplikasi BitRide.
@@ -21,14 +19,11 @@ import app.organicmaps.bitride.mesh.MeshManager
 @Composable
 fun AppNavigation() {
     val navController = rememberNavController()
-    val context = LocalContext.current
-
     NavHost(navController = navController, startDestination = Routes.AUTH) {
         composable(Routes.AUTH) {
             AuthScreen(
                 onNavigateToChooseRole = { navController.navigate(Routes.CHOOSE_ROLE) },
                 onNavigateToNextScreen = {
-                    MeshManager.start(context)
                     navController.navigate(Routes.CHOOSE_ROLE) {
                         popUpTo(Routes.AUTH) { inclusive = true }
                     }
@@ -77,7 +72,6 @@ fun AppNavigation() {
                 initialNik = nik,
                 initialName = name,
                 onRegistrationComplete = {
-                    MeshManager.start(context)
                     navController.navigate(Routes.CHOOSE_ROLE) {
                         popUpTo(Routes.AUTH) { inclusive = true }
                     }
@@ -98,7 +92,6 @@ fun AppNavigation() {
                 initialNik = nik,
                 initialName = name,
                 onRegistrationComplete = {
-                    MeshManager.start(context)
                     navController.navigate(Routes.CHOOSE_ROLE) {
                         popUpTo(Routes.AUTH) { inclusive = true }
                     }


### PR DESCRIPTION
## Ringkasan
- Hapus import dan pemanggilan `MeshManager.start` di `AppNavigation`
- Mulai mesh hanya saat driver login atau customer mengirim permintaan dari peta

## Pengujian
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)

------
https://chatgpt.com/codex/tasks/task_e_68a389777a1c83299ca3b2b0734874d6