### PR TITLE
Perbaiki penentuan role pengguna di ChooseRoleScreen

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -18,6 +19,7 @@ import android.content.Intent
 import app.organicmaps.MwmActivity
 import app.organicmaps.bitride.mesh.MeshManager
 import com.undefault.bitride.navigation.Routes
+import kotlinx.coroutines.flow.collect
 
 @Composable
 fun ChooseRoleScreen(
@@ -26,6 +28,14 @@ fun ChooseRoleScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
+
+    LaunchedEffect(navController) {
+        navController.currentBackStackEntryFlow.collect { backStackEntry ->
+            if (backStackEntry.destination.route == Routes.CHOOSE_ROLE) {
+                viewModel.refreshRoles()
+            }
+        }
+    }
 
     val navigateToNextScreen = { destination: String ->
         if (destination == Routes.DRIVER_LOUNGE) {

--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.undefault.bitride.data.repository.DataStoreRepository
 import com.undefault.bitride.data.repository.UserPreferencesRepository
+import com.undefault.bitride.data.model.Roles
 import app.organicmaps.downloader.DownloaderActivity
 import app.organicmaps.sdk.downloader.MapManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,16 +35,18 @@ class ChooseRoleViewModel @Inject constructor(
     val uiState = _uiState.asStateFlow()
 
     init {
-        viewModelScope.launch {
-            loadUserRoles()
-        }
+        viewModelScope.launch { loadUserRoles() }
+    }
+
+    fun refreshRoles() {
+        viewModelScope.launch { loadUserRoles() }
     }
 
     private suspend fun loadUserRoles() {
         val loggedInData = userPreferencesRepository.getLoggedInUser()
-        val roles = loggedInData?.roles ?: emptyList()
-        val hasDriverRole = roles.contains("DRIVER")
-        val hasCustomerRole = roles.contains("CUSTOMER")
+        val roles = loggedInData?.roles?.map { it.uppercase() } ?: emptyList()
+        val hasDriverRole = roles.contains(Roles.DRIVER)
+        val hasCustomerRole = roles.contains(Roles.CUSTOMER)
 
         _uiState.value = if (loggedInData == null) {
             ChooseRoleUiState(canRegisterDriver = true, canRegisterCustomer = true)

--- a/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
@@ -8,6 +8,7 @@ import com.undefault.bitride.data.repository.DataStoreRepository
 import com.undefault.bitride.data.repository.UserPreferencesRepository
 import com.undefault.bitride.data.repository.UserRepository
 import com.undefault.bitride.data.model.CustomerProfile
+import com.undefault.bitride.data.model.Roles
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -100,7 +101,7 @@ class CustomerRegistrationViewModel(application: Application) : AndroidViewModel
 
             val success = userRepository.createCustomerProfile(hashedNik, profile)
             if (success) {
-                userPreferencesRepository.saveLoggedInUser(hashedNik, "customer")
+                userPreferencesRepository.saveLoggedInUser(hashedNik, Roles.CUSTOMER)
                 Log.d("CustomerRegistrationVM", "Data customer disimpan ke storage lokal dan Firestore.")
                 _uiState.update { it.copy(isLoading = false, registrationSuccess = true) }
             } else {

--- a/app/src/google/java/com/undefault/bitride/data/model/Roles.kt
+++ b/app/src/google/java/com/undefault/bitride/data/model/Roles.kt
@@ -1,0 +1,6 @@
+package com.undefault.bitride.data.model
+
+object Roles {
+  const val DRIVER = "DRIVER"
+  const val CUSTOMER = "CUSTOMER"
+}

--- a/app/src/google/java/com/undefault/bitride/data/repository/DataStoreRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/DataStoreRepository.kt
@@ -70,10 +70,11 @@ class DataStoreRepository @Inject constructor(
     }
 
     suspend fun saveLoggedInUser(nikHash: String, role: String) {
+        val normalizedRole = role.uppercase()
         dataStore.edit { prefs ->
             prefs[KEY_NIK_HASH] = nikHash
             val roles = prefs[KEY_ROLES]?.split(",")?.toMutableSet() ?: mutableSetOf()
-            if (roles.add(role)) {
+            if (roles.add(normalizedRole)) {
                 prefs[KEY_ROLES] = roles.joinToString(",")
             }
         }

--- a/app/src/google/java/com/undefault/bitride/data/repository/UserPreferencesRepository.kt
+++ b/app/src/google/java/com/undefault/bitride/data/repository/UserPreferencesRepository.kt
@@ -14,11 +14,12 @@ class UserPreferencesRepository @Inject constructor(
     private val rolesCache = mutableSetOf<String>()
 
     suspend fun saveLoggedInUser(nikHash: String, role: String) {
+        val normalizedRole = role.uppercase()
         if (rolesCache.isEmpty()) {
             rolesCache.addAll(dataStoreRepository.rolesFlow.firstOrNull() ?: emptyList())
         }
-        rolesCache.add(role)
-        dataStoreRepository.saveLoggedInUser(nikHash, role)
+        rolesCache.add(normalizedRole)
+        dataStoreRepository.saveLoggedInUser(nikHash, normalizedRole)
     }
 
     suspend fun getLoggedInUser(): LoggedInData? {

--- a/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
@@ -8,6 +8,7 @@ import com.undefault.bitride.data.repository.DataStoreRepository
 import com.undefault.bitride.data.repository.UserPreferencesRepository
 import com.undefault.bitride.data.repository.UserRepository
 import com.undefault.bitride.data.model.DriverProfile
+import com.undefault.bitride.data.model.Roles
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -110,7 +111,7 @@ class DriverRegistrationViewModel(application: Application) : AndroidViewModel(a
 
             val success = userRepository.createDriverProfile(hashedNik, profile)
             if (success) {
-                userPreferencesRepository.saveLoggedInUser(hashedNik, "driver")
+                userPreferencesRepository.saveLoggedInUser(hashedNik, Roles.DRIVER)
                 Log.d("DriverRegistrationVM", "Data driver disimpan ke storage lokal dan Firestore.")
                 _uiState.update { it.copy(isLoading = false, registrationSuccess = true) }
             } else {

--- a/app/src/test/java/com/undefault/bitride/MainDispatcherRule.kt
+++ b/app/src/test/java/com/undefault/bitride/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.undefault.bitride
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+  val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+  override fun starting(description: Description) {
+    Dispatchers.setMain(dispatcher)
+  }
+
+  override fun finished(description: Description) {
+    Dispatchers.resetMain()
+  }
+}

--- a/app/src/test/java/com/undefault/bitride/chooserole/ChooseRoleViewModelTest.kt
+++ b/app/src/test/java/com/undefault/bitride/chooserole/ChooseRoleViewModelTest.kt
@@ -1,0 +1,76 @@
+package com.undefault.bitride.chooserole
+
+import android.content.Context
+import com.undefault.bitride.MainDispatcherRule
+import com.undefault.bitride.data.model.Roles
+import com.undefault.bitride.data.repository.DataStoreRepository
+import com.undefault.bitride.data.repository.LoggedInData
+import com.undefault.bitride.data.repository.UserPreferencesRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChooseRoleViewModelTest {
+  @get:Rule
+  val dispatcherRule = MainDispatcherRule()
+
+  private val context = Mockito.mock(Context::class.java)
+  private val userRepo = Mockito.mock(UserPreferencesRepository::class.java)
+  private val dataStore = Mockito.mock(DataStoreRepository::class.java)
+
+  @Test
+  fun noRolesCanRegisterBoth() = runTest {
+    Mockito.`when`(userRepo.getLoggedInUser()).thenReturn(null)
+    val vm = ChooseRoleViewModel(context, userRepo, dataStore)
+    vm.refreshRoles()
+    advanceUntilIdle()
+    assertEquals(
+      ChooseRoleUiState(canRegisterDriver = true, canRegisterCustomer = true),
+      vm.uiState.value
+    )
+  }
+
+  @Test
+  fun customerRoleShowsLoginCustomer() = runTest {
+    Mockito.`when`(userRepo.getLoggedInUser())
+      .thenReturn(LoggedInData("id", listOf(Roles.CUSTOMER)))
+    val vm = ChooseRoleViewModel(context, userRepo, dataStore)
+    vm.refreshRoles()
+    advanceUntilIdle()
+    assertEquals(
+      ChooseRoleUiState(canLoginAsCustomer = true, canRegisterDriver = true),
+      vm.uiState.value
+    )
+  }
+
+  @Test
+  fun driverRoleShowsLoginDriver() = runTest {
+    Mockito.`when`(userRepo.getLoggedInUser())
+      .thenReturn(LoggedInData("id", listOf(Roles.DRIVER)))
+    val vm = ChooseRoleViewModel(context, userRepo, dataStore)
+    vm.refreshRoles()
+    advanceUntilIdle()
+    assertEquals(
+      ChooseRoleUiState(canLoginAsDriver = true, canRegisterCustomer = true),
+      vm.uiState.value
+    )
+  }
+
+  @Test
+  fun bothRolesShowBothLogins() = runTest {
+    Mockito.`when`(userRepo.getLoggedInUser())
+      .thenReturn(LoggedInData("id", listOf(Roles.DRIVER, Roles.CUSTOMER)))
+    val vm = ChooseRoleViewModel(context, userRepo, dataStore)
+    vm.refreshRoles()
+    advanceUntilIdle()
+    assertEquals(
+      ChooseRoleUiState(canLoginAsDriver = true, canLoginAsCustomer = true),
+      vm.uiState.value
+    )
+  }
+}


### PR DESCRIPTION
## Ringkasan
- Tambah konstanta `Roles` agar penulisan peran konsisten
- Normalisasi penyimpanan role menjadi uppercase
- Muat ulang status role saat layar ChooseRole ditampilkan kembali
- Tambah unit test kombinasi role pengguna

## Pengujian
- `./gradlew :app:testDebugUnitTest -Dorg.gradle.java.home=$JAVA_HOME` *(gagal: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a492a4a08329a3a980da1d5af753