### PR TITLE
feat: dukung rute tujuan setelah unduhan

### DIFF
--- a/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
+++ b/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
@@ -3,7 +3,9 @@ package com.undefault.bitride.auth
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import app.organicmaps.DownloadResourcesLegacyActivity
 import com.undefault.bitride.navigation.AppNavigation
+import com.undefault.bitride.navigation.Routes
 import com.undefault.bitride.ui.theme.BitrideTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -11,9 +13,10 @@ import dagger.hilt.android.AndroidEntryPoint
 class AuthActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val startRoute = intent.getStringExtra(DownloadResourcesLegacyActivity.EXTRA_NEXT_ROUTE) ?: Routes.AUTH
         setContent {
             BitrideTheme {
-                AppNavigation()
+                AppNavigation(startDestination = startRoute)
             }
         }
     }

--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
@@ -72,6 +72,7 @@ class ChooseRoleViewModel @Inject constructor(
                 if (status != CountryItem.STATUS_DONE) {
                     val intent = Intent(context, DownloadResourcesLegacyActivity::class.java).apply {
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        putExtra(DownloadResourcesLegacyActivity.EXTRA_NEXT_ROUTE, destination)
                     }
                     context.startActivity(intent)
                     return@launch
@@ -92,6 +93,7 @@ class ChooseRoleViewModel @Inject constructor(
             } else {
                 val intent = Intent(context, DownloadResourcesLegacyActivity::class.java).apply {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    putExtra(DownloadResourcesLegacyActivity.EXTRA_NEXT_ROUTE, destination)
                 }
                 context.startActivity(intent)
             }

--- a/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
@@ -10,16 +10,16 @@ import com.undefault.bitride.auth.AuthScreen
 import com.undefault.bitride.chooserole.ChooseRoleScreen
 import com.undefault.bitride.customerregistrationform.CustomerRegistrationFormScreen
 import com.undefault.bitride.driverregistrationform.DriverRegistrationFormScreen
-import com.undefault.bitride.idcardscan.IdCardScanScreen
 import com.undefault.bitride.driverlounge.DriverLoungeScreen
+import com.undefault.bitride.idcardscan.IdCardScanScreen
 
 /**
  * Menangani navigasi aplikasi BitRide.
  */
 @Composable
-fun AppNavigation() {
+fun AppNavigation(startDestination: String = Routes.AUTH) {
     val navController = rememberNavController()
-    NavHost(navController = navController, startDestination = Routes.AUTH) {
+    NavHost(navController = navController, startDestination = startDestination) {
         composable(Routes.AUTH) {
             AuthScreen(
                 onNavigateToChooseRole = { navController.navigate(Routes.CHOOSE_ROLE) },

--- a/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -31,6 +31,7 @@ import androidx.annotation.StyleRes;
 import androidx.core.view.ViewCompat;
 import app.organicmaps.base.BaseMwmFragmentActivity;
 import app.organicmaps.intent.Factory;
+import app.organicmaps.MwmActivity;
 import app.organicmaps.sdk.Framework;
 import app.organicmaps.sdk.downloader.CountryItem;
 import app.organicmaps.sdk.downloader.MapManager;
@@ -42,6 +43,7 @@ import app.organicmaps.sdk.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.WindowInsetUtils.PaddingInsetsListener;
 import com.undefault.bitride.auth.AuthActivity;
+import com.undefault.bitride.navigation.Routes;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
 import java.util.List;
@@ -51,6 +53,7 @@ import java.util.Objects;
 public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
 {
   private static final String TAG = DownloadResourcesLegacyActivity.class.getSimpleName();
+  public static final String EXTRA_NEXT_ROUTE = "extra_next_route";
 
   private TextView mTvMessage;
   private LinearProgressIndicator mProgress;
@@ -338,15 +341,27 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
     // Re-use original intent to retain all flags and payload.
     // https://github.com/organicmaps/organicmaps/issues/6944
     final Intent intent = Objects.requireNonNull(getIntent());
-    intent.setComponent(new ComponentName(this, AuthActivity.class));
+    final String route = intent.getStringExtra(EXTRA_NEXT_ROUTE);
 
-    // Disable animation because AuthActivity should appear exactly over this one
+    Class<?> target = AuthActivity.class;
+    if (Routes.DRIVER_LOUNGE.equals(route))
+    {
+      intent.putExtra(EXTRA_NEXT_ROUTE, route);
+    }
+    else if ("peta lengkap".equals(route))
+    {
+      target = MwmActivity.class;
+    }
+
+    intent.setComponent(new ComponentName(this, target));
+
+    // Disable animation because target activity should appear exactly over this one
     intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
     // See {@link SplashActivity.processNavigation()}
     if (Factory.isStartedForApiResult(intent))
     {
-      // Wait for the result from AuthActivity for API callers.
+      // Wait for the result from target activity for API callers.
       mApiRequest.launch(intent);
       return;
     }

--- a/bitride/app/src/main/java/com/undefault/bitride/auth/AuthActivity.kt
+++ b/bitride/app/src/main/java/com/undefault/bitride/auth/AuthActivity.kt
@@ -3,7 +3,9 @@ package com.undefault.bitride.auth
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import app.organicmaps.DownloadResourcesLegacyActivity
 import com.undefault.bitride.navigation.AppNavigation
+import com.undefault.bitride.navigation.Routes
 import com.undefault.bitride.ui.theme.BitrideTheme // Ganti dengan nama tema aplikasi Anda
 
 class AuthActivity : ComponentActivity() {
@@ -11,10 +13,11 @@ class AuthActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val startRoute = intent.getStringExtra(DownloadResourcesLegacyActivity.EXTRA_NEXT_ROUTE) ?: Routes.AUTH
         setContent {
             // Menggunakan tema yang sudah didefinisikan untuk konsistensi UI
             BitrideTheme {
-                AppNavigation()
+                AppNavigation(startDestination = startRoute)
             }
         }
     }


### PR DESCRIPTION
## Ringkasan
- Tambah `EXTRA_NEXT_ROUTE` agar `DownloadResourcesLegacyActivity` bisa membuka layar berbeda setelah unduhan
- `AuthActivity` dan `AppNavigation` membaca ekstra rute untuk menentukan layar awal
- `ChooseRoleViewModel` meneruskan rute tujuan ketika memicu unduhan

## Pengujian
- `./gradlew test` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a407b954c08329bd13a4bae0536df1