### PR TITLE
feat: support post-download navigation

### DIFF
--- a/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
+++ b/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
@@ -4,16 +4,23 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.undefault.bitride.navigation.AppNavigation
+import com.undefault.bitride.navigation.Routes
 import com.undefault.bitride.ui.theme.BitrideTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class AuthActivity : ComponentActivity() {
+
+    companion object {
+        const val EXTRA_START_DESTINATION = "extra_start_destination"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val startDestination = intent.getStringExtra(EXTRA_START_DESTINATION) ?: Routes.AUTH
         setContent {
             BitrideTheme {
-                AppNavigation()
+                AppNavigation(startDestination)
             }
         }
     }

--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
@@ -72,6 +72,7 @@ class ChooseRoleViewModel @Inject constructor(
                 if (status != CountryItem.STATUS_DONE) {
                     val intent = Intent(context, DownloadResourcesLegacyActivity::class.java).apply {
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        putExtra(DownloadResourcesLegacyActivity.EXTRA_NEXT_ROUTE, destination)
                     }
                     context.startActivity(intent)
                     return@launch
@@ -92,6 +93,7 @@ class ChooseRoleViewModel @Inject constructor(
             } else {
                 val intent = Intent(context, DownloadResourcesLegacyActivity::class.java).apply {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    putExtra(DownloadResourcesLegacyActivity.EXTRA_NEXT_ROUTE, destination)
                 }
                 context.startActivity(intent)
             }

--- a/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
@@ -17,9 +17,9 @@ import com.undefault.bitride.driverlounge.DriverLoungeScreen
  * Menangani navigasi aplikasi BitRide.
  */
 @Composable
-fun AppNavigation() {
+fun AppNavigation(startDestination: String = Routes.AUTH) {
     val navController = rememberNavController()
-    NavHost(navController = navController, startDestination = Routes.AUTH) {
+    NavHost(navController = navController, startDestination = startDestination) {
         composable(Routes.AUTH) {
             AuthScreen(
                 onNavigateToChooseRole = { navController.navigate(Routes.CHOOSE_ROLE) },

--- a/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -42,6 +42,8 @@ import app.organicmaps.sdk.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.WindowInsetUtils.PaddingInsetsListener;
 import com.undefault.bitride.auth.AuthActivity;
+import com.undefault.bitride.navigation.Routes;
+import app.organicmaps.MwmActivity;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
 import java.util.List;
@@ -51,6 +53,7 @@ import java.util.Objects;
 public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
 {
   private static final String TAG = DownloadResourcesLegacyActivity.class.getSimpleName();
+  public static final String EXTRA_NEXT_ROUTE = "extra_next_route";
 
   private TextView mTvMessage;
   private LinearProgressIndicator mProgress;
@@ -338,7 +341,16 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
     // Re-use original intent to retain all flags and payload.
     // https://github.com/organicmaps/organicmaps/issues/6944
     final Intent intent = Objects.requireNonNull(getIntent());
-    intent.setComponent(new ComponentName(this, AuthActivity.class));
+    final String nextRoute = intent.getStringExtra(EXTRA_NEXT_ROUTE);
+    if (Routes.DRIVER_LOUNGE.equals(nextRoute))
+    {
+      intent.setComponent(new ComponentName(this, AuthActivity.class));
+      intent.putExtra(AuthActivity.EXTRA_START_DESTINATION, nextRoute);
+    }
+    else
+    {
+      intent.setComponent(new ComponentName(this, MwmActivity.class));
+    }
 
     // Disable animation because AuthActivity should appear exactly over this one
     intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION | Intent.FLAG_ACTIVITY_CLEAR_TOP);


### PR DESCRIPTION
## Summary
- add EXTRA_NEXT_ROUTE to DownloadResourcesLegacyActivity to control post-download screen
- allow AuthActivity/AppNavigation to accept initial route
- pass user role route from ChooseRoleViewModel to downloader

## Testing
- `./gradlew app:test -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 --no-daemon --console=plain` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a432ae47308329bd9d12b670c1d4a5