### PR TITLE
Gunakan path penyimpanan Organic Maps untuk pencarian peta

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleViewModel.kt
@@ -12,6 +12,7 @@ import app.organicmaps.DownloadResourcesLegacyActivity
 import app.organicmaps.MwmApplication
 import app.organicmaps.sdk.downloader.CountryItem
 import app.organicmaps.sdk.downloader.MapManager
+import app.organicmaps.sdk.Framework
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -88,14 +89,15 @@ class ChooseRoleViewModel @Inject constructor(
                 return@launch
             }
 
+            val mapsDir = File(Framework.nativeGetWritableDir())
             val mapsDownloaded = MapManager.nativeGetDownloadedCount() > 0
-            val brouterDir = File(context.filesDir, "brouter/segments4")
+            val brouterDir = File(mapsDir, "brouter/segments4")
             val brouterReady = brouterDir.exists() &&
                 (brouterDir.listFiles()?.any { it.name.endsWith(".rd5") } == true)
 
             if (mapsDownloaded && brouterReady) {
-                val mapFile = context.filesDir.listFiles()?.firstOrNull { it.extension == "mwm" }
-                val dbFile = context.filesDir.listFiles()?.firstOrNull { it.extension == "db" }
+                val mapFile = mapsDir.listFiles()?.firstOrNull { it.extension == "mwm" }
+                val dbFile = mapsDir.listFiles()?.firstOrNull { it.extension == "db" }
                 mapFile?.let { dataStoreRepository.setActiveMapFileName(it.name) }
                 dbFile?.let { dataStoreRepository.setActivePoiDbName(it.name) }
                 onResult(destination)


### PR DESCRIPTION
## Ringkasan
- Gunakan `Framework.nativeGetWritableDir()` sebagai dasar path pencarian berkas peta/POI dan data BRouter.
- Simpan nama berkas peta dan POI ke `DataStoreRepository` setelah ditemukan.

## Pengujian
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68a453e662e083299baf8cc4f6318daf