### PR TITLE
Tambahkan rute Auth setelah unduhan

### DIFF
--- a/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -33,6 +33,7 @@ import app.organicmaps.sdk.util.log.Logger;
 import app.organicmaps.util.SharingUtils;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.Utils;
+import com.undefault.bitride.navigation.Routes;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import java.io.IOException;
 import java.util.Objects;
@@ -208,6 +209,7 @@ public class SplashActivity extends AppCompatActivity
     else
     {
       intent.setComponent(new ComponentName(this, DownloadResourcesLegacyActivity.class));
+      intent.putExtra(DownloadResourcesLegacyActivity.EXTRA_NEXT_ROUTE, Routes.AUTH);
     }
 
     // FLAG_ACTIVITY_NEW_TASK and FLAG_ACTIVITY_RESET_TASK_IF_NEEDED break the cold start.


### PR DESCRIPTION
## Ringkasan
- arahkan pengguna ke AuthActivity setelah unduhan dengan EXTRA_NEXT_ROUTE
- impor `Routes` untuk mendefinisikan tujuan setelah unduhan

## Pengujian
- ⚠️ `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127 karena skrip `../tools/unix/version.sh` tidak ditemukan)


------
https://chatgpt.com/codex/tasks/task_e_68a46c27d5b88329bcd64b64cd26108b