### PR TITLE
Route to AuthActivity for non-driver destinations

### DIFF
--- a/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -423,6 +423,11 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
       intent.setComponent(new ComponentName(this, AuthActivity.class));
       intent.putExtra(AuthActivity.EXTRA_START_DESTINATION, nextRoute);
     }
+    else if (!TextUtils.isEmpty(nextRoute))
+    {
+      intent.setComponent(new ComponentName(this, AuthActivity.class));
+      intent.putExtra(AuthActivity.EXTRA_START_DESTINATION, nextRoute);
+    }
     else
     {
       intent.setComponent(new ComponentName(this, MwmActivity.class));


### PR DESCRIPTION
## Summary
- Redirect any non-driver route to AuthActivity and pass along the start destination

## Testing
- `./gradlew test` (fails: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)


------
https://chatgpt.com/codex/tasks/task_e_68a4ba93c5748329bfd71db5a5ec3228