### PR TITLE
Tunda showMap sampai negara ditemukan

### DIFF
--- a/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -123,6 +123,26 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
         mChbDownloadCountry.setText(checkBoxText);
       }
 
+      if (mAreResourcesDownloaded)
+      {
+        if (status != CountryItem.STATUS_DONE && mChbDownloadCountry.isChecked())
+        {
+          CountryItem item = CountryItem.fill(mCurrentCountry);
+          UiUtils.hide(mChbDownloadCountry);
+          mTvMessage.setText(getString(R.string.downloading_country_can_proceed, item.name));
+          mProgress.setMax((int) item.totalSize);
+          mProgress.setProgressCompat(0, true);
+
+          mCountryDownloadListenerSlot = MapManager.nativeSubscribe(mCountryDownloadListener);
+          MapManager.startDownload(mCurrentCountry);
+          setAction(PROCEED_TO_MAP);
+        }
+        else
+        {
+          showMap();
+        }
+      }
+
       MwmApplication.from(DownloadResourcesLegacyActivity.this).getLocationHelper().removeListener(this);
     }
   };
@@ -466,6 +486,11 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
         mCountryDownloadListenerSlot = MapManager.nativeSubscribe(mCountryDownloadListener);
         MapManager.startDownload(mCurrentCountry);
         setAction(PROCEED_TO_MAP);
+      }
+      else if (mCurrentCountry == null)
+      {
+        mAreResourcesDownloaded = true;
+        MwmApplication.from(this).getLocationHelper().addListener(mLocationListener);
       }
       else
       {


### PR DESCRIPTION
## Ringkasan
- Aktifkan kembali `LocationHelper` jika negara belum terdeteksi setelah unduhan selesai dan tunggu hingga `MapManager.nativeFindCountry` berhasil.
- Jalankan proses unduhan peta negara secara otomatis atau buka peta setelah lokasi ditemukan.

## Pengujian
- `./gradlew test` (gagal: Java home yang disetel tidak valid)


------
https://chatgpt.com/codex/tasks/task_e_68a4bf14ee48832988b147186b175b30