### PR TITLE
Lewati AuthActivity untuk rute MAP_HOME

### DIFF
--- a/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -438,19 +438,15 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
     // https://github.com/organicmaps/organicmaps/issues/6944
     final Intent intent = Objects.requireNonNull(getIntent());
     final String nextRoute = intent.getStringExtra(EXTRA_NEXT_ROUTE);
-    if (Routes.DRIVER_LOUNGE.equals(nextRoute))
+    if (TextUtils.isEmpty(nextRoute) || Routes.MAP_HOME.equals(nextRoute))
     {
-      intent.setComponent(new ComponentName(this, AuthActivity.class));
-      intent.putExtra(AuthActivity.EXTRA_START_DESTINATION, nextRoute);
-    }
-    else if (!TextUtils.isEmpty(nextRoute))
-    {
-      intent.setComponent(new ComponentName(this, AuthActivity.class));
-      intent.putExtra(AuthActivity.EXTRA_START_DESTINATION, nextRoute);
+      intent.setComponent(new ComponentName(this, MwmActivity.class));
+      intent.removeExtra(AuthActivity.EXTRA_START_DESTINATION);
     }
     else
     {
-      intent.setComponent(new ComponentName(this, MwmActivity.class));
+      intent.setComponent(new ComponentName(this, AuthActivity.class));
+      intent.putExtra(AuthActivity.EXTRA_START_DESTINATION, nextRoute);
     }
 
     // Disable animation because AuthActivity should appear exactly over this one


### PR DESCRIPTION
## Ringkasan
- Hindari pengalihan ke AuthActivity bila rute berikutnya MAP_HOME dan hilangkan extra `EXTRA_START_DESTINATION`.
- Rute lain tetap diarahkan ke AuthActivity dengan extra tujuan awal.

## Pengujian
- `./gradlew test -Dorg.gradle.java.home=$(dirname $(dirname $(readlink -f $(which java))))` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68a4ce0c0bac8329bd92a8f0a3f04cf2