### PR TITLE
Gunakan Hilt pada DriverRegistrationViewModel dan segarkan peran setelah pendaftaran

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -30,6 +30,7 @@ fun ChooseRoleScreen(
     val context = LocalContext.current
 
     LaunchedEffect(navController) {
+        viewModel.refreshRoles()
         navController.currentBackStackEntryFlow.collect { backStackEntry ->
             if (backStackEntry.destination.route == Routes.CHOOSE_ROLE) {
                 viewModel.refreshRoles()


### PR DESCRIPTION
## Ringkasan
- Refactor `DriverRegistrationViewModel` menjadi `@HiltViewModel` dan injeksi `UserPreferencesRepository` serta `DataStoreRepository`.
- Tunda penandaan keberhasilan registrasi hingga `saveLoggedInUser` selesai.
- Jalankan `refreshRoles` saat `ChooseRoleScreen` muncul kembali agar tombol "Masuk sebagai Driver" tampil.

## Pengujian
- `./gradlew -p app test` *(gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)*


------
https://chatgpt.com/codex/tasks/task_e_68a4dae37c848329b49de55095cb1c7c