### PR TITLE
Tambahkan guard GMS untuk operasi Firestore dan registrasi

### DIFF
--- a/app/src/google/java/com/undefault/bitride/util/GmsGuard.kt
+++ b/app/src/google/java/com/undefault/bitride/util/GmsGuard.kt
@@ -1,0 +1,25 @@
+package com.undefault.bitride.util
+
+import android.content.Context
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+
+object GmsGuard {
+    fun isGmsAvailable(context: Context): Boolean {
+        val availability = GoogleApiAvailability.getInstance()
+        return availability.isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
+    }
+}
+
+suspend fun <T> runWithGms(
+    context: Context,
+    onAvailable: suspend () -> T,
+    onUnavailable: suspend () -> T
+): T {
+    return if (GmsGuard.isGmsAvailable(context)) {
+        onAvailable()
+    } else {
+        onUnavailable()
+    }
+}
+


### PR DESCRIPTION
## Ringkasan
- buat utilitas `GmsGuard` dan helper `runWithGms` untuk memeriksa ketersediaan Google Play Services
- bungkus operasi Firestore di `UserRepository` dengan `runWithGms` agar memiliki fallback
- gunakan `runWithGms` pada `CustomerRegistrationViewModel` dan `DriverRegistrationViewModel` sebelum memanggil repositori

## Pengujian
- `./gradlew test` *(gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68a897a57668832995a9efa3ee4bba27