### PR TITLE
Guard Firestore calls with Hilt-injected repository

### DIFF
--- a/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationFormScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationFormScreen.kt
@@ -8,11 +8,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
 fun CustomerRegistrationFormScreen(
-    viewModel: CustomerRegistrationViewModel = viewModel(),
+    viewModel: CustomerRegistrationViewModel = hiltViewModel(),
     initialNik: String? = null,
     initialName: String? = null,
     onRegistrationComplete: () -> Unit, // Tipe diubah, tidak perlu hash

--- a/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/customerregistrationform/CustomerRegistrationViewModel.kt
@@ -1,13 +1,15 @@
 package com.undefault.bitride.customerregistrationform
 
-import android.app.Application
+import android.content.Context
 import android.util.Log
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.firestore.FirebaseFirestore
 import com.undefault.bitride.data.repository.UserPreferencesRepository
 import com.undefault.bitride.data.repository.UserRepository
 import com.undefault.bitride.util.runWithGms
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,14 +26,15 @@ data class CustomerRegistrationFormState(
     val registrationSuccess: Boolean = false
 )
 
-class CustomerRegistrationViewModel(application: Application) : AndroidViewModel(application) {
+@HiltViewModel
+class CustomerRegistrationViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
+    @ApplicationContext private val context: Context
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CustomerRegistrationFormState())
     val uiState: StateFlow<CustomerRegistrationFormState> = _uiState.asStateFlow()
-
-    // PASS Firestore ke constructor
-    private val userRepository = UserRepository(FirebaseFirestore.getInstance(), application)
-    private val userPreferencesRepository = UserPreferencesRepository(application)
 
     fun processScannedData(scannedNik: String?, scannedName: String?) {
         _uiState.update { currentState ->
@@ -92,7 +95,7 @@ class CustomerRegistrationViewModel(application: Application) : AndroidViewModel
                 return@launch
             }
 
-            runWithGms(getApplication(), {
+            runWithGms(context, {
                 val roleExists = userRepository.doesRoleExist(hashedNik, "CUSTOMER")
                 if (roleExists) {
                     _uiState.update { it.copy(isLoading = false, validationError = "Akun Customer dengan NIK ini sudah terdaftar.") }

--- a/app/src/google/java/com/undefault/bitride/di/FirebaseModule.kt
+++ b/app/src/google/java/com/undefault/bitride/di/FirebaseModule.kt
@@ -3,6 +3,7 @@ package com.undefault.bitride.di
 import android.content.Context
 import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.FirebaseFirestore
+import com.undefault.bitride.data.repository.UserRepository
 import com.undefault.bitride.firebase.BitrideFirebase
 import dagger.Module
 import dagger.Provides
@@ -28,4 +29,11 @@ object FirebaseModule {
         }
         return FirebaseFirestore.getInstance(app)
     }
+
+    @Provides
+    @Singleton
+    fun provideUserRepository(
+        firestore: FirebaseFirestore,
+        @ApplicationContext context: Context
+    ): UserRepository = UserRepository(firestore, context)
 }

--- a/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationFormScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationFormScreen.kt
@@ -8,11 +8,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
 fun DriverRegistrationFormScreen(
-    viewModel: DriverRegistrationViewModel = viewModel(),
+    viewModel: DriverRegistrationViewModel = hiltViewModel(),
     initialNik: String? = null,
     initialName: String? = null,
     onRegistrationComplete: () -> Unit, // Tipe diubah, tidak perlu hash

--- a/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/driverregistrationform/DriverRegistrationViewModel.kt
@@ -1,13 +1,15 @@
 package com.undefault.bitride.driverregistrationform
 
-import android.app.Application
+import android.content.Context
 import android.util.Log
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.firestore.FirebaseFirestore
 import com.undefault.bitride.data.repository.UserPreferencesRepository
 import com.undefault.bitride.data.repository.UserRepository
 import com.undefault.bitride.util.runWithGms
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,14 +28,15 @@ data class DriverRegistrationFormState(
     val registrationSuccess: Boolean = false
 )
 
-class DriverRegistrationViewModel(application: Application) : AndroidViewModel(application) {
+@HiltViewModel
+class DriverRegistrationViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
+    @ApplicationContext private val context: Context
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DriverRegistrationFormState())
     val uiState: StateFlow<DriverRegistrationFormState> = _uiState.asStateFlow()
-
-    // PASS Firestore ke constructor
-    private val userRepository = UserRepository(FirebaseFirestore.getInstance(), application)
-    private val userPreferencesRepository = UserPreferencesRepository(application)
 
     fun onNikChange(nik: String) {
         _uiState.update { currentState ->
@@ -102,7 +105,7 @@ class DriverRegistrationViewModel(application: Application) : AndroidViewModel(a
                 return@launch
             }
 
-            runWithGms(getApplication(), {
+            runWithGms(context, {
                 val roleExists = userRepository.doesRoleExist(hashedNik, "DRIVER")
                 if (roleExists) {
                     _uiState.update { it.copy(isLoading = false, validationError = "Akun Driver dengan NIK ini sudah terdaftar.") }


### PR DESCRIPTION
## Summary
- provide `UserRepository` via `FirebaseModule`
- inject `UserRepository` and `UserPreferencesRepository` into registration viewmodels
- use `hiltViewModel()` in registration screens

## Testing
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME :app:compileGoogleDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a891a13bcc8329babcb925a4e1be75