### PR TITLE
Tentukan tipe Unit untuk runWithGms di RegisterViewModel

### DIFF
--- a/app/src/google/java/com/undefault/bitride/auth/RegisterViewModel.kt
+++ b/app/src/google/java/com/undefault/bitride/auth/RegisterViewModel.kt
@@ -18,7 +18,7 @@ class RegisterViewModel @Inject constructor(
 
     fun registerCustomer(nikHash: String, onResult: (Boolean) -> Unit) {
         viewModelScope.launch {
-            context.runWithGms(
+            context.runWithGms<Unit>(
                 onAvailable = {
                     val success = userRepository.createCustomerProfile(nikHash)
                     onResult(success)
@@ -32,7 +32,7 @@ class RegisterViewModel @Inject constructor(
 
     fun registerDriver(nikHash: String, onResult: (Boolean) -> Unit) {
         viewModelScope.launch {
-            context.runWithGms(
+            context.runWithGms<Unit>(
                 onAvailable = {
                     val success = userRepository.createDriverProfile(nikHash)
                     onResult(success)


### PR DESCRIPTION
## Ringkasan
- Pastikan pemanggilan `runWithGms` dalam `RegisterViewModel` menggunakan tipe generic `Unit` agar inferensi tipe tidak gagal.

## Pengujian
- `./gradlew app:compileGoogleDebugKotlin -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c7aea9c88329ba00a8b99c60f733