### PR TITLE
Tampilkan unduhan peta sebelum pemilihan peran

### DIFF
--- a/app/src/google/AndroidManifest.xml
+++ b/app/src/google/AndroidManifest.xml
@@ -11,5 +11,9 @@
             android:name="com.undefault.bitride.auth.AuthActivity"
             android:exported="false" />
 
+        <activity
+            android:name="com.undefault.bitride.downloader.AutoDownloadActivity"
+            android:exported="false" />
+
     </application>
 </manifest>

--- a/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
+++ b/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
@@ -1,8 +1,11 @@
 package com.undefault.bitride.auth
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import app.organicmaps.sdk.downloader.MapManager
+import com.undefault.bitride.downloader.AutoDownloadActivity
 import com.undefault.bitride.navigation.AppNavigation
 import com.undefault.bitride.ui.theme.BitrideTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -11,6 +14,9 @@ import dagger.hilt.android.AndroidEntryPoint
 class AuthActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (MapManager.nativeGetDownloadedCount() == 0) {
+            startActivity(Intent(this, AutoDownloadActivity::class.java))
+        }
         setContent {
             BitrideTheme {
                 AppNavigation()

--- a/app/src/google/java/com/undefault/bitride/downloader/AutoDownloadActivity.kt
+++ b/app/src/google/java/com/undefault/bitride/downloader/AutoDownloadActivity.kt
@@ -1,0 +1,22 @@
+package com.undefault.bitride.downloader
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import app.organicmaps.base.BaseMwmFragmentActivity
+import app.organicmaps.downloader.CountrySuggestFragment
+
+class AutoDownloadActivity : BaseMwmFragmentActivity() {
+    override fun getFragmentClass(): Class<out Fragment> = CountrySuggestFragment::class.java
+
+    override fun onSafeCreate(savedInstanceState: Bundle?) {
+        super.onSafeCreate(savedInstanceState)
+        supportFragmentManager.registerFragmentLifecycleCallbacks(object : FragmentManager.FragmentLifecycleCallbacks() {
+            override fun onFragmentDetached(fm: FragmentManager, fragment: Fragment) {
+                if (fragment is CountrySuggestFragment) {
+                    finish()
+                }
+            }
+        }, false)
+    }
+}


### PR DESCRIPTION
## Ringkasan
- Tambahkan `AutoDownloadActivity` untuk menampilkan `CountrySuggestFragment` sebelum pengguna memilih peran.
- Panggil `AutoDownloadActivity` dari `AuthActivity` jika belum ada peta terunduh.
- Deklarasikan `AutoDownloadActivity` pada AndroidManifest flavor Google.

## Pengujian
- ❌ `./gradlew :app:compileGoogleDebugKotlin` (gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)


------
https://chatgpt.com/codex/tasks/task_e_68ab500cc76883298dc657807b121cc4