### PR TITLE
Tampilkan unduhan peta sebelum pemilihan peran

### DIFF
--- a/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
+++ b/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
@@ -1,16 +1,39 @@
 package com.undefault.bitride.auth
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import app.organicmaps.base.BaseMwmFragmentActivity
+import app.organicmaps.downloader.CountrySuggestFragment
+import app.organicmaps.sdk.downloader.MapManager
 import com.undefault.bitride.navigation.AppNavigation
 import com.undefault.bitride.ui.theme.BitrideTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class AuthActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+class AuthActivity : BaseMwmFragmentActivity() {
+    override fun getFragmentClass(): Class<out Fragment>? = null
+
+    override fun onSafeCreate(savedInstanceState: Bundle?) {
+        super.onSafeCreate(savedInstanceState)
+        if (MapManager.nativeGetDownloadedCount() == 0) {
+            supportFragmentManager.registerFragmentLifecycleCallbacks(object : FragmentManager.FragmentLifecycleCallbacks() {
+                override fun onFragmentDetached(fm: FragmentManager, fragment: Fragment) {
+                    if (fragment is CountrySuggestFragment) {
+                        showContent()
+                    }
+                }
+            }, false)
+            supportFragmentManager.beginTransaction()
+                .add(android.R.id.content, CountrySuggestFragment(), CountrySuggestFragment::class.java.name)
+                .commitAllowingStateLoss()
+        } else {
+            showContent()
+        }
+    }
+
+    private fun showContent() {
         setContent {
             BitrideTheme {
                 AppNavigation()


### PR DESCRIPTION
## Ringkasan
- Panggil `CountrySuggestFragment` langsung dari `AuthActivity` jika belum ada peta yang terunduh
- Hapus `AutoDownloadActivity` dan deklarasinya dari AndroidManifest

## Pengujian
- ❌ `./gradlew :app:compileGoogleDebugKotlin` (Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68ab500cc76883298dc657807b121cc4