### PR TITLE
feat: layar unduh peta sebelum pemilihan peran

### DIFF
--- a/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
+++ b/app/src/google/java/com/undefault/bitride/auth/AuthActivity.kt
@@ -1,14 +1,14 @@
 package com.undefault.bitride.auth
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.fragment.app.FragmentActivity
 import com.undefault.bitride.navigation.AppNavigation
 import com.undefault.bitride.ui.theme.BitrideTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class AuthActivity : ComponentActivity() {
+class AuthActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/app/src/google/java/com/undefault/bitride/mapdownload/MapDownloadScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/mapdownload/MapDownloadScreen.kt
@@ -1,0 +1,57 @@
+package com.undefault.bitride.mapdownload
+
+import android.view.View
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentContainerView
+import androidx.navigation.NavController
+import app.organicmaps.downloader.CountrySuggestFragment
+import app.organicmaps.sdk.downloader.MapManager
+import com.undefault.bitride.navigation.Routes
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+@Composable
+fun MapDownloadScreen(navController: NavController) {
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        if (MapManager.nativeGetDownloadedCount() > 0) {
+            navController.navigate(Routes.CHOOSE_ROLE) {
+                popUpTo(Routes.MAP_DOWNLOAD) { inclusive = true }
+            }
+        } else {
+            while (isActive) {
+                delay(1000)
+                if (MapManager.nativeGetDownloadedCount() > 0) {
+                    navController.navigate(Routes.CHOOSE_ROLE) {
+                        popUpTo(Routes.MAP_DOWNLOAD) { inclusive = true }
+                    }
+                    break
+                }
+            }
+        }
+    }
+
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { ctx ->
+            FragmentContainerView(ctx).apply { id = View.generateViewId() }
+        },
+        update = { view ->
+            val activity = context as FragmentActivity
+            val fm = activity.supportFragmentManager
+            if (fm.findFragmentById(view.id) == null) {
+                fm.beginTransaction()
+                    .replace(view.id, CountrySuggestFragment())
+                    .commit()
+            }
+        }
+    )
+}
+

--- a/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.undefault.bitride.chooserole.ChooseRoleScreen
+import com.undefault.bitride.mapdownload.MapDownloadScreen
 import com.undefault.bitride.customerregistrationform.CustomerRegistrationFormScreen
 import com.undefault.bitride.driverregistrationform.DriverRegistrationFormScreen
 import com.undefault.bitride.idcardscan.IdCardScanScreen
@@ -28,7 +29,10 @@ fun AppNavigation() {
     val navController = rememberNavController()
     val context = LocalContext.current
 
-    NavHost(navController = navController, startDestination = Routes.CHOOSE_ROLE) {
+    NavHost(navController = navController, startDestination = Routes.MAP_DOWNLOAD) {
+        composable(Routes.MAP_DOWNLOAD) {
+            MapDownloadScreen(navController)
+        }
         composable(Routes.CHOOSE_ROLE) {
             ChooseRoleScreen(navController)
         }

--- a/app/src/google/java/com/undefault/bitride/navigation/Routes.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/Routes.kt
@@ -4,6 +4,7 @@ package com.undefault.bitride.navigation
  * Kumpulan konstanta rute yang digunakan pada sistem navigasi BitRide.
  */
 object Routes {
+    const val MAP_DOWNLOAD = "map_download"
     const val CHOOSE_ROLE = "choose_role"
     const val ID_CARD_SCAN = "id_card_scan"
     const val CUSTOMER_REGISTRATION_FORM = "customer_registration_form"

--- a/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -34,6 +34,7 @@ import app.organicmaps.util.SharingUtils;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.Utils;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.undefault.bitride.auth.AuthActivity;
 import java.io.IOException;
 import java.util.Objects;
 
@@ -207,7 +208,10 @@ public class SplashActivity extends AppCompatActivity
     }
     else
     {
-      intent.setComponent(new ComponentName(this, DownloadResourcesLegacyActivity.class));
+      if (app.organicmaps.sdk.DownloadResourcesLegacyActivity.nativeGetBytesToDownload() > 0)
+        intent.setComponent(new ComponentName(this, DownloadResourcesLegacyActivity.class));
+      else
+        intent.setComponent(new ComponentName(this, AuthActivity.class));
     }
 
     // FLAG_ACTIVITY_NEW_TASK and FLAG_ACTIVITY_RESET_TASK_IF_NEEDED break the cold start.


### PR DESCRIPTION
## Ringkasan
- tambah `MapDownloadScreen` untuk unduh peta awal
- ubah navigasi agar dimulai dari `MapDownloadScreen`
- perbarui `SplashActivity` mengecek unduhan resource dasar

## Pengujian
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68ab7652c37c8329ba6d2b355d2bb094