### PR TITLE
Gunakan ID tetap untuk kontainer unduhan peta

### DIFF
--- a/app/src/google/java/com/undefault/bitride/mapdownload/MapDownloadScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/mapdownload/MapDownloadScreen.kt
@@ -1,15 +1,16 @@
 package com.undefault.bitride.mapdownload
 
-import android.view.View
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.doOnAttach
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
 import androidx.navigation.NavController
+import app.organicmaps.R
 import app.organicmaps.downloader.CountrySuggestFragment
 import app.organicmaps.sdk.downloader.MapManager
 import com.undefault.bitride.navigation.Routes
@@ -41,15 +42,17 @@ fun MapDownloadScreen(navController: NavController) {
     AndroidView(
         modifier = Modifier.fillMaxSize(),
         factory = { ctx ->
-            FragmentContainerView(ctx).apply { id = View.generateViewId() }
+            FragmentContainerView(ctx).apply { id = R.id.map_download_container }
         },
         update = { view ->
             val activity = context as FragmentActivity
             val fm = activity.supportFragmentManager
             if (fm.findFragmentById(view.id) == null) {
-                fm.beginTransaction()
-                    .replace(view.id, CountrySuggestFragment())
-                    .commit()
+                view.doOnAttach {
+                    fm.beginTransaction()
+                        .replace(view.id, CountrySuggestFragment())
+                        .commitNow()
+                }
             }
         }
     )

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="map_download_container" type="id"/>
+</resources>


### PR DESCRIPTION
## Ringkasan
- Tambah resource `map_download_container` sebagai ID tetap.
- `MapDownloadScreen` memakai ID tersebut dan `commitNow()` setelah view terlampir.

## Pengujian
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/17.0.2 :app:assembleGoogleDebug` *(gagal: tidak menemukan script `../tools/unix/version.sh`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ea633348329ba0ee6a37a43c925