### PR TITLE
Cek status peta berdasarkan lokasi sebelum lanjut

### DIFF
--- a/app/src/google/java/com/undefault/bitride/mapdownload/MapDownloadScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/mapdownload/MapDownloadScreen.kt
@@ -1,8 +1,7 @@
 package com.undefault.bitride.mapdownload
 
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
@@ -12,6 +11,8 @@ import androidx.fragment.app.FragmentContainerView
 import androidx.navigation.NavController
 import app.organicmaps.R
 import app.organicmaps.downloader.CountrySuggestFragment
+import app.organicmaps.MwmApplication
+import app.organicmaps.sdk.downloader.CountryItem
 import app.organicmaps.sdk.downloader.MapManager
 import com.undefault.bitride.navigation.Routes
 import kotlinx.coroutines.delay
@@ -20,16 +21,26 @@ import kotlinx.coroutines.isActive
 @Composable
 fun MapDownloadScreen(navController: NavController) {
     val context = LocalContext.current
+    var showSuggest by remember { mutableStateOf(true) }
 
     LaunchedEffect(Unit) {
-        if (MapManager.nativeGetDownloadedCount() > 0) {
+        suspend fun isMapReady(): Boolean {
+            val location = MwmApplication.from(context).getLocationHelper().getSavedLocation()
+            val countryId = location?.let { MapManager.nativeFindCountry(it.latitude, it.longitude) }
+            return !countryId.isNullOrEmpty() &&
+                    MapManager.nativeGetStatus(countryId) == CountryItem.STATUS_DONE
+        }
+
+        if (isMapReady()) {
+            showSuggest = false
             navController.navigate(Routes.CHOOSE_ROLE) {
                 popUpTo(Routes.MAP_DOWNLOAD) { inclusive = true }
             }
         } else {
             while (isActive) {
                 delay(1000)
-                if (MapManager.nativeGetDownloadedCount() > 0) {
+                if (isMapReady()) {
+                    showSuggest = false
                     navController.navigate(Routes.CHOOSE_ROLE) {
                         popUpTo(Routes.MAP_DOWNLOAD) { inclusive = true }
                     }
@@ -39,22 +50,24 @@ fun MapDownloadScreen(navController: NavController) {
         }
     }
 
-    AndroidView(
-        modifier = Modifier.fillMaxSize(),
-        factory = { ctx ->
-            FragmentContainerView(ctx).apply { id = R.id.map_download_container }
-        },
-        update = { view ->
-            val activity = context as FragmentActivity
-            val fm = activity.supportFragmentManager
-            if (fm.findFragmentById(view.id) == null) {
-                view.doOnAttach {
-                    fm.beginTransaction()
-                        .replace(view.id, CountrySuggestFragment())
-                        .commitNow()
+    if (showSuggest) {
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { ctx ->
+                FragmentContainerView(ctx).apply { id = R.id.map_download_container }
+            },
+            update = { view ->
+                val activity = context as FragmentActivity
+                val fm = activity.supportFragmentManager
+                if (fm.findFragmentById(view.id) == null) {
+                    view.doOnAttach {
+                        fm.beginTransaction()
+                            .replace(view.id, CountrySuggestFragment())
+                            .commitNow()
+                    }
                 }
             }
-        }
-    )
+        )
+    }
 }
 


### PR DESCRIPTION
## Ringkasan
- Periksa status peta berdasarkan lokasi perangkat sebelum navigasi
- Tampilkan CountrySuggestFragment sampai peta wilayah selesai diunduh

## Pengujian
- `./gradlew test` (gagal: Java home invalid)


------
https://chatgpt.com/codex/tasks/task_e_68ab833ecf308329a4d18820af2fd74f