### PR TITLE
Integrasi alur unduhan pertama ke MwmActivity

### DIFF
--- a/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -41,7 +41,6 @@ import app.organicmaps.sdk.util.StringUtils;
 import app.organicmaps.sdk.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.WindowInsetUtils.PaddingInsetsListener;
-import com.undefault.bitride.auth.AuthActivity;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
 import java.util.List;
@@ -66,6 +65,7 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
   private ActivityResultLauncher<Intent> mApiRequest;
 
   private boolean mAreResourcesDownloaded;
+  private boolean mProceedFromButton;
 
   private static final int DOWNLOAD = 0;
   private static final int PAUSE = 1;
@@ -327,6 +327,7 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
   private void onProceedToMapClicked()
   {
     mAreResourcesDownloaded = true;
+    mProceedFromButton = true;
     showMap();
   }
 
@@ -338,15 +339,17 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
     // Re-use original intent to retain all flags and payload.
     // https://github.com/organicmaps/organicmaps/issues/6944
     final Intent intent = Objects.requireNonNull(getIntent());
-    intent.setComponent(new ComponentName(this, AuthActivity.class));
+    intent.setComponent(new ComponentName(this, MwmActivity.class));
+    intent.putExtra(MwmActivity.EXTRA_FIRST_RUN, true);
+    intent.putExtra(MwmActivity.EXTRA_SKIP_TO_AUTH, mProceedFromButton && !mChbDownloadCountry.isChecked());
 
-    // Disable animation because AuthActivity should appear exactly over this one
+    // Disable animation because MwmActivity should appear exactly over this one
     intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
     // See {@link SplashActivity.processNavigation()}
     if (Factory.isStartedForApiResult(intent))
     {
-      // Wait for the result from AuthActivity for API callers.
+      // Wait for the result from MwmActivity for API callers.
       mApiRequest.launch(intent);
       return;
     }

--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -97,6 +97,7 @@ import app.organicmaps.sdk.display.DisplayChangedListener;
 import app.organicmaps.sdk.display.DisplayManager;
 import app.organicmaps.sdk.display.DisplayType;
 import app.organicmaps.sdk.downloader.MapManager;
+import app.organicmaps.sdk.downloader.CountryItem;
 import app.organicmaps.sdk.downloader.UpdateInfo;
 import app.organicmaps.sdk.editor.Editor;
 import app.organicmaps.sdk.editor.OsmOAuth;
@@ -118,6 +119,8 @@ import app.organicmaps.sdk.util.PowerManagment;
 import app.organicmaps.sdk.util.UiUtils;
 import app.organicmaps.sdk.util.log.Logger;
 import app.organicmaps.sdk.widget.placepage.PlacePageData;
+import com.undefault.bitride.auth.AuthActivity;
+import java.util.List;
 import app.organicmaps.search.FloatingSearchToolbarController;
 import app.organicmaps.search.SearchActivity;
 import app.organicmaps.search.SearchFragment;
@@ -160,6 +163,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public static final String EXTRA_UPDATE_THEME = "update_theme";
   public static final String EXTRA_DEST_LAT = "dest_lat";
   public static final String EXTRA_DEST_LON = "dest_lon";
+  public static final String EXTRA_FIRST_RUN = "first_run";
+  public static final String EXTRA_SKIP_TO_AUTH = "skip_to_auth";
   private static final String EXTRA_CONSUMED = "mwm.extra.intent.processed";
   private boolean mPreciseLocationDialogShown = false;
 
@@ -193,6 +198,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Nullable
   private OnmapDownloader mOnmapDownloader;
   private boolean mIsTabletLayout;
+  private boolean mFirstRun;
+  private boolean mSkipToAuth;
+  private int mCountryDownloadListenerSlot;
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
   private FloatingSearchToolbarController mSearchController;
@@ -207,6 +215,37 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private PlacePageViewModel mPlacePageViewModel;
   private MapButtonsViewModel mMapButtonsViewModel;
   private MapButtonsController.LayoutMode mPreviousMapLayoutMode;
+
+  private final MapManager.StorageCallback mCountryDownloadListener = new MapManager.StorageCallback()
+  {
+    @Override
+    public void onStatusChanged(List<MapManager.StorageCallbackData> data)
+    {
+      if (!mFirstRun)
+        return;
+
+      for (MapManager.StorageCallbackData item : data)
+      {
+        if (!item.isLeafNode)
+          continue;
+
+        if (item.newStatus == CountryItem.STATUS_DONE)
+        {
+          goToAuthActivity();
+          return;
+        }
+
+        if (item.newStatus == CountryItem.STATUS_FAILED)
+          MapManager.showError(MwmActivity.this, item, null);
+      }
+    }
+
+    @Override
+    public void onProgress(String countryId, long localSize, long remoteSize)
+    {
+      // No op.
+    }
+  };
 
   @Nullable
   private WindowInsetsCompat mCurrentWindowInsets;
@@ -368,6 +407,20 @@ public class MwmActivity extends BaseMwmFragmentActivity
     {
       sIsFirstLaunch = false;
       showSearch("");
+    }
+
+    if (mFirstRun)
+    {
+      if (MwmApplication.from(this).getLocationHelper().isInFirstRun())
+        MwmApplication.from(this).getLocationHelper().onExitFromFirstRun();
+
+      if (mOnmapDownloader != null)
+        mOnmapDownloader.updateState(true);
+
+      if (mSkipToAuth)
+        goToAuthActivity();
+      else
+        checkAuthTransition();
     }
 
   }
@@ -652,6 +705,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mDisplayManager.addListener(DisplayType.Device, this);
 
     final Intent intent = getIntent();
+    mFirstRun = intent != null && intent.getBooleanExtra(EXTRA_FIRST_RUN, false);
+    mSkipToAuth = intent != null && intent.getBooleanExtra(EXTRA_SKIP_TO_AUTH, false);
     final boolean isLaunchByDeepLink = intent != null && !intent.hasCategory(Intent.CATEGORY_LAUNCHER);
     initViews(isLaunchByDeepLink);
     mPickupBackButton = findViewById(R.id.pickup_back_button);
@@ -1297,6 +1352,15 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (mOnmapDownloader != null)
       mOnmapDownloader.onResume();
 
+    if (mFirstRun)
+    {
+      if (Map.isEngineCreated() && MwmApplication.from(this).getLocationHelper().isInFirstRun())
+        MwmApplication.from(this).getLocationHelper().onExitFromFirstRun();
+
+      if (mCountryDownloadListenerSlot == 0)
+        mCountryDownloadListenerSlot = MapManager.nativeSubscribe(mCountryDownloadListener);
+    }
+
     mNavigationController.refresh();
     refreshLightStatusBar();
 
@@ -1324,6 +1388,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     if (mOnmapDownloader != null)
       mOnmapDownloader.onPause();
+
+    if (mFirstRun && mCountryDownloadListenerSlot != 0)
+    {
+      MapManager.nativeUnsubscribe(mCountryDownloadListenerSlot);
+      mCountryDownloadListenerSlot = 0;
+    }
     MwmApplication.from(this).getSensorHelper().removeListener(this);
     dismissLocationErrorDialog();
     dismissAlertDialog();
@@ -3039,6 +3109,23 @@ public class MwmActivity extends BaseMwmFragmentActivity
     Logger.d(TAG, "trim memory, level = " + level);
     if (level >= TRIM_MEMORY_RUNNING_LOW)
       Framework.nativeMemoryWarning();
+  }
+  private void checkAuthTransition()
+  {
+    if (!mFirstRun)
+      return;
+
+    View downloader = findViewById(R.id.onmap_downloader);
+    if (downloader == null || downloader.getVisibility() != View.VISIBLE)
+      goToAuthActivity();
+  }
+
+  private void goToAuthActivity()
+  {
+    Intent intent = new Intent(this, AuthActivity.class);
+    intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+    startActivity(intent);
+    finish();
   }
   private static String sha256(String s)
   {


### PR DESCRIPTION
## Ringkasan
- Ubah DownloadResourcesLegacyActivity agar membuka MwmActivity dan mengirimkan flag alur pertama
- MwmActivity menangani alur pertama: mengikuti posisi GPS, menampilkan OnmapDownloader, dan lanjut ke AuthActivity

## Pengujian
- `./gradlew test` (gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)


------
https://chatgpt.com/codex/tasks/task_e_68ac086b6a9083299080522fd3f3eb6d