### PR TITLE
Route map through MwmActivity before auth

### DIFF
--- a/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -41,7 +41,6 @@ import app.organicmaps.sdk.util.StringUtils;
 import app.organicmaps.sdk.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.WindowInsetUtils.PaddingInsetsListener;
-import com.undefault.bitride.auth.AuthActivity;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
 import java.util.List;
@@ -338,15 +337,16 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
     // Re-use original intent to retain all flags and payload.
     // https://github.com/organicmaps/organicmaps/issues/6944
     final Intent intent = Objects.requireNonNull(getIntent());
-    intent.setComponent(new ComponentName(this, AuthActivity.class));
+    intent.setComponent(new ComponentName(this, MwmActivity.class));
+    intent.putExtra(MwmActivity.EXTRA_RETURN_TO_AUTH, true);
 
-    // Disable animation because AuthActivity should appear exactly over this one
+    // Disable animation because MwmActivity should appear exactly over this one
     intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
     // See {@link SplashActivity.processNavigation()}
     if (Factory.isStartedForApiResult(intent))
     {
-      // Wait for the result from AuthActivity for API callers.
+      // Wait for the result from MwmActivity for API callers.
       mApiRequest.launch(intent);
       return;
     }


### PR DESCRIPTION
## Summary
- alihkan intent hasil unduhan ke `MwmActivity` dengan penanda untuk kembali ke autentikasi
- di `MwmActivity`, pantau status unduhan peta dan buka `AuthActivity` setelah siap

## Testing
- `./gradlew test -Dorg.gradle.java.home=$JAVA_HOME` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4cd06d688329967c0443eb346fdb