### PR TITLE
Delay auth return until user map is downloaded

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -209,7 +209,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     @Override
     public void onStatusChanged(List<MapManager.StorageCallbackData> data)
     {
-      if (!MapManager.nativeIsDownloading() && MapManager.nativeGetDownloadedCount() > 0)
+      if (!MapManager.nativeIsDownloading() && MapManager.nativeGetDownloadedCount() > 1)
         openAuthAndFinish();
     }
 
@@ -680,7 +680,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mReturnToAuth = intent != null && intent.getBooleanExtra(EXTRA_RETURN_TO_AUTH, false);
     if (mReturnToAuth)
     {
-      if (!MapManager.nativeIsDownloading() && MapManager.nativeGetDownloadedCount() > 0)
+      if (!MapManager.nativeIsDownloading() && MapManager.nativeGetDownloadedCount() > 1)
       {
         openAuthAndFinish();
         return;


### PR DESCRIPTION
## Summary
- avoid returning to auth until at least one local map beyond the world map is downloaded

## Testing
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME_DIR test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6c52ce488329890c891774dcdc91