### PR TITLE
Check auth return via local map availability

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1241,10 +1241,15 @@ public class MwmActivity extends BaseMwmFragmentActivity
       mPanelAnimator.registerListener(mOnmapDownloader);
   }
 
+  /**
+   * Checks whether we can return to the authentication flow.
+   * This relies on the availability of a map covering the screen center
+   * rather than the total number of downloaded maps.
+   */
   private boolean shouldReturnToAuth()
   {
     return !MapManager.nativeIsDownloading()
-        && MapManager.nativeGetDownloadedCount() > MIN_DOWNLOADED_MAPS;
+        && Framework.nativeIsDownloadedMapAtScreenCenter();
   }
 
   private void openAuthAndFinish()


### PR DESCRIPTION
## Summary
- ensure auth flow only triggers when a map covering screen center is downloaded
- document that the check depends on local map presence, not total downloads

## Testing
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68ac77eac31c8329b71d0c2f59d14bbb