### PR TITLE
Tunda halaman search hingga setelah autentikasi

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -1,5 +1,6 @@
 package com.undefault.bitride.chooserole
 
+import android.app.Activity
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
@@ -13,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
+import app.organicmaps.search.SearchActivity
 import app.organicmaps.bitride.mesh.MeshManager
 import com.undefault.bitride.navigation.Routes
 
@@ -25,10 +27,16 @@ fun ChooseRoleScreen(
     val context = LocalContext.current
 
     val navigateToNextScreen = { destination: String ->
-        navController.navigate(destination) {
-            // Bersihkan semua layar sebelumnya sampai ke awal
-            popUpTo(navController.graph.startDestinationId) { inclusive = true }
-            launchSingleTop = true
+        if (destination == Routes.MAIN) {
+            val activity = context as Activity
+            SearchActivity.start(activity, "")
+            activity.finish()
+        } else {
+            navController.navigate(destination) {
+                // Bersihkan semua layar sebelumnya sampai ke awal
+                popUpTo(navController.graph.startDestinationId) { inclusive = true }
+                launchSingleTop = true
+            }
         }
     }
 

--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -392,7 +392,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (sIsFirstLaunch)
     {
       sIsFirstLaunch = false;
-      showSearch("");
+      if (!mReturnToAuth)
+        showSearch("");
     }
 
   }


### PR DESCRIPTION
## Ringkasan
- Hindari pemanggilan awal SearchActivity saat peluncuran pertama
- Navigasikan tombol "Masuk sebagai Customer" langsung ke SearchActivity
- Perbaiki lambda navigasi agar tipe kembalian sesuai dan kompilasi berhasil

## Pengujian
- `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 ./gradlew test --console=plain` *(gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4a46b964832990eeed656653a728