### PR TITLE
Pastikan switchToMyPosition dijalankan setelah engine siap

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -389,6 +389,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
     processIntent();
     migrateOAuthCredentials();
 
+    setupInitialLocation();
+
     if (sIsFirstLaunch)
     {
       sIsFirstLaunch = false;
@@ -858,7 +860,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     initMainMenu();
     initOnmapDownloader();
-    setupInitialLocation();
     initPositionChooser();
   }
 
@@ -927,6 +928,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private void switchToMyPosition()
   {
+    if (!Framework.nativeIsEngineCreated())
+      return;
+
     final int mode = LocationState.getMode();
     if (mode != FOLLOW && mode != FOLLOW_AND_ROTATE)
       LocationState.nativeSwitchToNextMode();


### PR DESCRIPTION
## Ringkasan
- Pindahkan `setupInitialLocation()` dari `initViews()` ke `onRenderingInitializationFinished()` agar dipanggil setelah render siap
- Tambahkan pengecekan `Framework.nativeIsEngineCreated()` sebelum `switchToMyPosition()` dipanggil

## Pengujian
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68ac861ba9cc8329abdb1ee0ea77cb75