### PR TITLE
Handle return to auth after map download

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1268,6 +1268,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
     finish();
   }
 
+  public void onCountryDownloadFinished()
+  {
+    if (mReturnToAuth && shouldReturnToAuth())
+      openAuthAndFinish();
+  }
+
   @Override
   protected void onSaveInstanceState(@NonNull Bundle outState)
   {

--- a/app/src/main/java/app/organicmaps/downloader/OnmapDownloader.java
+++ b/app/src/main/java/app/organicmaps/downloader/OnmapDownloader.java
@@ -59,6 +59,9 @@ public class OnmapDownloader implements MwmActivity.LeftAnimationTrackListener
           mCurrentCountry.update();
           updateProgressState(false);
 
+          if (item.newStatus == CountryItem.STATUS_DONE)
+            mActivity.onCountryDownloadFinished();
+
           return;
         }
       }


### PR DESCRIPTION
## Summary
- trigger auth screen once selected map download completes when return-to-auth flag is active

## Testing
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68ac87325c2883299165e11b3041858f