### PR TITLE
Trigger on-map downloader after first GPS fix

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -911,6 +911,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (myPosition != null)
     {
       switchToMyPosition();
+      if (mOnmapDownloader != null)
+        mOnmapDownloader.updateState(true);
       return;
     }
     mFirstFixListener = new LocationListener()
@@ -921,6 +923,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
         locationHelper.removeListener(this);
         mFirstFixListener = null;
         switchToMyPosition();
+        if (mOnmapDownloader != null)
+          mOnmapDownloader.updateState(true);
       }
     };
     locationHelper.addListener(mFirstFixListener);


### PR DESCRIPTION
## Summary
- ensure switchToMyPosition and on-map downloader update run after the first GPS fix

## Testing
- `./gradlew -Dorg.gradle.java.home=$HOME/.local/share/mise/installs/java/21.0.2 test` *(failed: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68ac88833e288329a94d2dd0bc2b3580