### PR TITLE
Delay auth until map zooms to user position

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -1,5 +1,6 @@
 package com.undefault.bitride.chooserole
 
+import android.app.Activity
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
@@ -13,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
+import app.organicmaps.search.SearchActivity
 import app.organicmaps.bitride.mesh.MeshManager
 import com.undefault.bitride.navigation.Routes
 
@@ -25,10 +27,16 @@ fun ChooseRoleScreen(
     val context = LocalContext.current
 
     val navigateToNextScreen = { destination: String ->
-        navController.navigate(destination) {
-            // Bersihkan semua layar sebelumnya sampai ke awal
-            popUpTo(navController.graph.startDestinationId) { inclusive = true }
-            launchSingleTop = true
+        if (destination == Routes.MAIN) {
+            val activity = context as Activity
+            SearchActivity.start(activity, "")
+            activity.finish()
+        } else {
+            navController.navigate(destination) {
+                // Bersihkan semua layar sebelumnya sampai ke awal
+                popUpTo(navController.graph.startDestinationId) { inclusive = true }
+                launchSingleTop = true
+            }
         }
     }
 

--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -116,6 +116,7 @@ import app.organicmaps.sdk.util.Config;
 import app.organicmaps.sdk.util.LocationUtils;
 import app.organicmaps.sdk.util.PowerManagment;
 import app.organicmaps.sdk.util.UiUtils;
+import app.organicmaps.sdk.util.concurrency.UiThread;
 import app.organicmaps.sdk.util.log.Logger;
 import app.organicmaps.sdk.widget.placepage.PlacePageData;
 import app.organicmaps.search.FloatingSearchToolbarController;
@@ -389,10 +390,13 @@ public class MwmActivity extends BaseMwmFragmentActivity
     processIntent();
     migrateOAuthCredentials();
 
+    setupInitialLocation();
+
     if (sIsFirstLaunch)
     {
       sIsFirstLaunch = false;
-      showSearch("");
+      if (!mReturnToAuth)
+        showSearch("");
     }
 
   }
@@ -680,14 +684,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     final boolean isLaunchByDeepLink = intent != null && !intent.hasCategory(Intent.CATEGORY_LAUNCHER);
     mReturnToAuth = intent != null && intent.getBooleanExtra(EXTRA_RETURN_TO_AUTH, false);
     if (mReturnToAuth)
-    {
-      if (shouldReturnToAuth())
-      {
-        openAuthAndFinish();
-        return;
-      }
       mReturnToAuthSlot = MapManager.nativeSubscribe(mReturnToAuthCallback);
-    }
 
     initViews(isLaunchByDeepLink);
     mPickupBackButton = findViewById(R.id.pickup_back_button);
@@ -857,7 +854,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     initMainMenu();
     initOnmapDownloader();
-    setupInitialLocation();
     initPositionChooser();
   }
 
@@ -926,9 +922,15 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private void switchToMyPosition()
   {
+    if (!Map.isEngineCreated())
+      return;
     final int mode = LocationState.getMode();
     if (mode != FOLLOW && mode != FOLLOW_AND_ROTATE)
       LocationState.nativeSwitchToNextMode();
+    if (mReturnToAuth && shouldReturnToAuth())
+      openAuthAndFinish();
+    if (mOnmapDownloader != null)
+      mOnmapDownloader.updateState(true);
   }
 
   private void refreshSearchToolbar()
@@ -1249,7 +1251,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private boolean shouldReturnToAuth()
   {
     return !MapManager.nativeIsDownloading()
-        && Framework.nativeIsDownloadedMapAtScreenCenter();
+        && Framework.nativeIsDownloadedMapAtScreenCenter()
+        && MwmApplication.from(this).getLocationHelper().getMyPosition() != null;
   }
 
   private void openAuthAndFinish()
@@ -1259,8 +1262,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
       MapManager.nativeUnsubscribe(mReturnToAuthSlot);
       mReturnToAuthSlot = 0;
     }
-    startActivity(new Intent(this, AuthActivity.class));
-    finish();
+    UiThread.runLater(() -> {
+      startActivity(new Intent(this, AuthActivity.class));
+      finish();
+    });
   }
 
   @Override


### PR DESCRIPTION
## Summary
- Auto-zoom to user location after engine initialization so map download prompt appears
- Show authentication screen only after local map is ready using UI thread

## Testing
- `./gradlew test -Dorg.gradle.java.home=$JAVA_HOME` *(fails: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4a46b964832990eeed656653a728