### PR TITLE
Perbaiki alur awal peta dan pemilihan peran

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -1,5 +1,7 @@
 package com.undefault.bitride.chooserole
 
+import android.app.Activity
+import android.content.Intent
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
@@ -13,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
+import app.organicmaps.MwmActivity
 import app.organicmaps.bitride.mesh.MeshManager
 import com.undefault.bitride.navigation.Routes
 
@@ -23,14 +26,6 @@ fun ChooseRoleScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
-
-    val navigateToNextScreen = { destination: String ->
-        navController.navigate(destination) {
-            // Bersihkan semua layar sebelumnya sampai ke awal
-            popUpTo(navController.graph.startDestinationId) { inclusive = true }
-            launchSingleTop = true
-        }
-    }
 
     Scaffold { paddingValues ->
         Column(
@@ -44,7 +39,11 @@ fun ChooseRoleScreen(
             if (uiState.canLoginAsCustomer) {
                 Button(onClick = {
                     MeshManager.start(context)
-                    viewModel.checkDataAndGetNextRoute(navigateToNextScreen)
+                    val intent = Intent(context, MwmActivity::class.java).apply {
+                        putExtra(MwmActivity.EXTRA_SHOW_SEARCH, true)
+                    }
+                    context.startActivity(intent)
+                    (context as? Activity)?.finish()
                 }) {
                     Text("Masuk sebagai Customer")
                 }

--- a/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
@@ -1,5 +1,7 @@
 package com.undefault.bitride.navigation
 
+import android.app.Activity
+import android.content.Intent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
@@ -18,6 +20,7 @@ import com.undefault.bitride.customerregistrationform.CustomerRegistrationFormSc
 import com.undefault.bitride.driverregistrationform.DriverRegistrationFormScreen
 import com.undefault.bitride.idcardscan.IdCardScanScreen
 import com.undefault.bitride.driverlounge.DriverLoungeScreen
+import app.organicmaps.MwmActivity
 import app.organicmaps.bitride.mesh.MeshManager
 
 /**
@@ -72,9 +75,11 @@ fun AppNavigation() {
                 initialName = name,
                 onRegistrationComplete = {
                     MeshManager.start(context)
-                    navController.navigate(Routes.MAIN) {
-                        popUpTo(Routes.CHOOSE_ROLE) { inclusive = true }
+                    val intent = Intent(context, MwmActivity::class.java).apply {
+                        putExtra(MwmActivity.EXTRA_SHOW_SEARCH, true)
                     }
+                    context.startActivity(intent)
+                    (context as? Activity)?.finish()
                 },
                 onNavigateToScanKtp = { navController.navigate(Routes.idCardScanWithArgs("customer", true)) }
             )
@@ -93,7 +98,7 @@ fun AppNavigation() {
                 initialName = name,
                 onRegistrationComplete = {
                     MeshManager.start(context)
-                    navController.navigate(Routes.MAIN) {
+                    navController.navigate(Routes.DRIVER_LOUNGE) {
                         popUpTo(Routes.CHOOSE_ROLE) { inclusive = true }
                     }
                 },

--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -163,6 +163,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public static final String EXTRA_DEST_LAT = "dest_lat";
   public static final String EXTRA_DEST_LON = "dest_lon";
   public static final String EXTRA_RETURN_TO_AUTH = "return_to_auth";
+  public static final String EXTRA_SHOW_SEARCH = "show_search";
   private static final String EXTRA_CONSUMED = "mwm.extra.intent.processed";
   private static final int MIN_DOWNLOADED_MAPS = 1;
   private boolean mPreciseLocationDialogShown = false;
@@ -390,9 +391,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
     migrateOAuthCredentials();
 
     if (sIsFirstLaunch)
-    {
       sIsFirstLaunch = false;
+
+    if (getIntent().getBooleanExtra(EXTRA_SHOW_SEARCH, false))
+    {
       showSearch("");
+      getIntent().removeExtra(EXTRA_SHOW_SEARCH);
     }
 
   }


### PR DESCRIPTION
## Ringkasan
- Tambahkan flag EXTRA_SHOW_SEARCH pada MwmActivity untuk menampilkan layar pencarian sesuai kebutuhan alur.
- Pindahkan logika pemilihan peran: login customer membuka MwmActivity dengan Search, sementara driver menuju Driver Lounge.
- Sesuaikan navigasi registrasi supaya customer kembali ke peta dan driver menuju lounge.

## Pengujian
- `./gradlew -Dorg.gradle.java.home=$ORG_GRADLE_JAVA_HOME test` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68ac96d875048329a340a808bdcc169d