### PR TITLE
Trigger on-map downloader after initial location

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -861,7 +861,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     initMainMenu();
     initOnmapDownloader();
+    if (mOnmapDownloader != null)
+      mOnmapDownloader.onResume();
     setupInitialLocation();
+    if (mOnmapDownloader != null)
+      mOnmapDownloader.updateState(true);
     initPositionChooser();
   }
 


### PR DESCRIPTION
## Summary
- ensure on-map downloader subscription active before initial location setup
- trigger automatic downloader popup after location initialization

## Testing
- `./gradlew test` *(fails: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4a096dc8329a0961f39334c03dc