### PR TITLE
Stabilize role navigation lambda

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -27,13 +27,13 @@ fun ChooseRoleScreen(
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
 
-    val navigateToNextScreen = { destination: String ->
+    val navigateToNextScreen: (String) -> Unit = { destination ->
         if (destination == Routes.MAIN) {
             context.startActivity(
                 Intent(context, MwmActivity::class.java)
                     .putExtra(MwmActivity.EXTRA_SHOW_SEARCH, true)
             )
-            (context as? Activity)?.finish()
+            (context as? Activity)?.finish() ?: Unit
         } else {
             navController.navigate(destination) {
                 // Bersihkan semua layar sebelumnya sampai ke awal

--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -947,6 +947,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
     final int mode = LocationState.getMode();
     if (mode != FOLLOW && mode != FOLLOW_AND_ROTATE)
       LocationState.nativeSwitchToNextMode();
+    if (mOnmapDownloader != null)
+      mOnmapDownloader.updateState(true);
   }
 
   private void refreshSearchToolbar()


### PR DESCRIPTION
## Summary
- Fix ChooseRoleScreen navigate lambda return type to satisfy Function1<String, Unit>
- Trigger local map downloader after GPS position fix so users see local map suggestion

## Testing
- `./gradlew :app:compileGoogleDebugKotlin` *(fails: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68aca1ff28a08329ab60ef8f7a45c20b