### PR TITLE
Integrasi peta awal dan alur pemilihan peran

### DIFF
--- a/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
+++ b/app/src/google/java/com/undefault/bitride/chooserole/ChooseRoleScreen.kt
@@ -27,13 +27,13 @@ fun ChooseRoleScreen(
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
 
-    val navigateToNextScreen = { destination: String ->
+    val navigateToNextScreen: (String) -> Unit = { destination ->
         if (destination == Routes.MAIN) {
             context.startActivity(
                 Intent(context, MwmActivity::class.java)
                     .putExtra(MwmActivity.EXTRA_SHOW_SEARCH, true)
             )
-            (context as? Activity)?.finish()
+            (context as? Activity)?.finish() ?: Unit
         } else {
             navController.navigate(destination) {
                 // Bersihkan semua layar sebelumnya sampai ke awal

--- a/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
+++ b/app/src/google/java/com/undefault/bitride/navigation/AppNavigation.kt
@@ -107,7 +107,10 @@ fun AppNavigation() {
         composable(Routes.MAIN) {
             val context = LocalContext.current
             LaunchedEffect(Unit) {
-                context.startActivity(Intent(context, MwmActivity::class.java))
+                context.startActivity(
+                    Intent(context, MwmActivity::class.java)
+                        .putExtra(MwmActivity.EXTRA_SHOW_SEARCH, true)
+                )
                 (context as? Activity)?.finish()
             }
         }

--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -947,6 +947,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
     final int mode = LocationState.getMode();
     if (mode != FOLLOW && mode != FOLLOW_AND_ROTATE)
       LocationState.nativeSwitchToNextMode();
+    if (mOnmapDownloader != null)
+      mOnmapDownloader.updateState(true);
   }
 
   private void refreshSearchToolbar()


### PR DESCRIPTION
## Ringkasan
- Memunculkan unduhan peta lokal otomatis setelah posisi awal didapat
- Stabilkan transisi ke AuthActivity dan tampilkan pencarian hanya bila diminta
- Integrasi layar pemilihan peran dengan peta utama

## Testing
- Tidak ada pengujian karena lingkungan tidak mendukung build

------
https://chatgpt.com/codex/tasks/task_e_68aca1ff28a08329ab60ef8f7a45c20b