### PR TITLE
Allow location updates in first run when required

### DIFF
--- a/app/src/main/java/app/organicmaps/sdk/location/LocationHelper.java
+++ b/app/src/main/java/app/organicmaps/sdk/location/LocationHelper.java
@@ -55,6 +55,7 @@ public class LocationHelper implements BaseLocationProvider.Listener
   private BaseLocationProvider mLocationProvider;
   private long mInterval;
   private boolean mInFirstRun;
+  private boolean mAllowUpdatesInFirstRun;
   private boolean mActive;
   private Handler mHandler;
   private Runnable mLocationTimeoutRunnable = this::notifyLocationUpdateTimeout;
@@ -159,7 +160,7 @@ public class LocationHelper implements BaseLocationProvider.Listener
     // If we are still in the first run mode, i.e. user is staying on the first run screens,
     // not on the map, we mustn't post location update to the core. Only this preserving allows us
     // to play nice zoom animation once a user will leave first screens and will see a map.
-    if (mInFirstRun)
+    if (mInFirstRun && !mAllowUpdatesInFirstRun)
     {
       Logger.d(TAG, "Location update is obtained and must be ignored, because the app is in a first run mode");
       return;
@@ -470,6 +471,18 @@ public class LocationHelper implements BaseLocationProvider.Listener
   {
     Logger.i(TAG);
     mInFirstRun = true;
+  }
+
+  @UiThread
+  public void allowLocationUpdatesInFirstRun()
+  {
+    Logger.i(TAG, "Allowing location updates during first run");
+    if (mAllowUpdatesInFirstRun)
+      return;
+
+    mAllowUpdatesInFirstRun = true;
+    if (mInFirstRun && mSavedLocation != null)
+      notifyLocationUpdated();
   }
 
   @UiThread


### PR DESCRIPTION
## Ringkasan
- Tambahkan flag `mAllowUpdatesInFirstRun` agar pembaruan lokasi tetap dikirim saat first-run jika diperlukan
- Sediakan metode `allowLocationUpdatesInFirstRun` untuk mengaktifkan logika tersebut
- Sesuaikan pemeriksaan `mInFirstRun` agar bisa dilewati ketika flag diaktifkan

## Pengujian
- `./gradlew test -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)


------
https://chatgpt.com/codex/tasks/task_e_68acc7cfe99083299cd447f8508c1e2b