### PR TITLE
Tampilkan dialog saat gagal mendeteksi lokasi

### DIFF
--- a/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -476,7 +476,24 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
 
     mPendingShowMap = false;
     mProgress.setIndeterminate(false);
-    mAreResourcesDownloaded = true;
-    openAuth();
+
+    if (mAlertDialog != null && mAlertDialog.isShowing())
+      return;
+
+    mAlertDialog = new MaterialAlertDialogBuilder(this)
+        .setTitle(R.string.current_location_unknown_error_title)
+        .setMessage(R.string.enable_location_services)
+        .setPositiveButton(R.string.downloader_retry, (dialog, which) -> waitForCountryAndShowMap())
+        .setNegativeButton(R.string.continue_button, (dialog, which) -> {
+          mAreResourcesDownloaded = true;
+          openAuth();
+        })
+        .setOnCancelListener(dialog -> {
+          mAreResourcesDownloaded = true;
+          openAuth();
+        })
+        .setOnDismissListener(dialog -> mAlertDialog = null)
+        .create();
+    mAlertDialog.show();
   }
 }


### PR DESCRIPTION
## Ringkasan
- Tampilkan dialog ketika aplikasi tidak bisa menemukan lokasi pengguna agar dapat mencoba ulang atau melanjutkan ke Auth

## Pengujian
- `./gradlew test` (gagal: Process 'command 'bash'' finished with non-zero exit value 127)

------
https://chatgpt.com/codex/tasks/task_e_68acc998a094832989f04eb71d921627