### PR TITLE
Tangani crash setelah unduhan peta

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1295,6 +1295,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
         return;
       }
 
+      Logger.i(TAG, "Starting AuthActivity and finishing MwmActivity");
       startActivity(new Intent(this, AuthActivity.class));
       finish();
     });

--- a/sdk/src/main/cpp/app/organicmaps/sdk/platform/GuiThread.cpp
+++ b/sdk/src/main/cpp/app/organicmaps/sdk/platform/GuiThread.cpp
@@ -1,6 +1,7 @@
 #include "app/organicmaps/sdk/platform/GuiThread.hpp"
 
 #include "app/organicmaps/sdk/core/jni_helper.hpp"
+#include "base/logging.hpp"
 
 #include <memory>
 
@@ -26,8 +27,25 @@ GuiThread::~GuiThread()
 // static
 void GuiThread::ProcessTask(jlong task)
 {
+  if (task == 0)
+  {
+    LOG(LWARNING, ("GuiThread::ProcessTask called with null task"));
+    return;
+  }
+
   std::unique_ptr<Task> t(reinterpret_cast<Task *>(task));
-  (*t)();
+  try
+  {
+    (*t)();
+  }
+  catch (std::exception const & e)
+  {
+    LOG(LERROR, ("Exception while executing gui task:", e.what()));
+  }
+  catch (...)
+  {
+    LOG(LERROR, ("Unknown exception while executing gui task"));
+  }
 }
 
 base::TaskLoop::PushResult GuiThread::Push(Task && task)


### PR DESCRIPTION
## Ringkasan
- Tambah penanganan null dan pengecualian di GuiThread untuk mencegah crash saat task GUI dijalankan.
- Tambah log ketika berpindah dari MwmActivity ke AuthActivity.

## Pengujian
- `./gradlew test` *(gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid (Java home supplied is invalid))*


------
https://chatgpt.com/codex/tasks/task_e_68acd1c8122c8329afc56359f9f565ca