### PR TITLE
Ganti intent showMap ke AuthActivity

### DIFF
--- a/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -357,16 +357,15 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
     // Re-use original intent to retain all flags and payload.
     // https://github.com/organicmaps/organicmaps/issues/6944
     final Intent intent = Objects.requireNonNull(getIntent());
-    intent.setComponent(new ComponentName(this, MwmActivity.class));
-    intent.putExtra(MwmActivity.EXTRA_RETURN_TO_AUTH, true);
+    intent.setComponent(new ComponentName(this, com.undefault.bitride.auth.AuthActivity.class));
 
-    // Disable animation because MwmActivity should appear exactly over this one
+    // Disable animation because AuthActivity should appear exactly over this one
     intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
     // See {@link SplashActivity.processNavigation()}
     if (Factory.isStartedForApiResult(intent))
     {
-      // Wait for the result from MwmActivity for API callers.
+      // Wait for the result from AuthActivity for API callers.
       mApiRequest.launch(intent);
       return;
     }


### PR DESCRIPTION
## Ringkasan
- Arahkan intent `showMap()` ke `com.undefault.bitride.auth.AuthActivity` dan hilangkan `MwmActivity.EXTRA_RETURN_TO_AUTH`.
- Pertahankan flag dan penutupan aktivitas saat menampilkan layar autentikasi.

## Pengujian
- `./gradlew test` *(gagal: Value 'C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68acef5bde248329a1f666fdf12f7a04