### PR TITLE
feat: guard auth flow on active downloads

### DIFF
--- a/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1251,16 +1251,16 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     runOnUiThread(() ->
     {
-      if (mOnmapDownloader != null)
-      {
-        mOnmapDownloader.onPause();
-        mOnmapDownloader = null;
-      }
-
       if (MapManager.nativeIsDownloading())
       {
         Logger.w(TAG, "Engine is not idle when returning to auth");
         return;
+      }
+
+      if (mOnmapDownloader != null)
+      {
+        mOnmapDownloader.onPause();
+        mOnmapDownloader = null;
       }
 
       startActivity(new Intent(this, AuthActivity.class));


### PR DESCRIPTION
## Ringkasan
- Cegah `openAuthAndFinish()` menutup aktivitas saat engine masih mengunduh peta

## Pengujian
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` *(gagal: Process 'command 'bash'' finished with non-zero exit value 127)*

------
https://chatgpt.com/codex/tasks/task_e_68acf387607083298980af9f540fb422